### PR TITLE
Add button loading states and module PDF upload

### DIFF
--- a/app/admin/page.js
+++ b/app/admin/page.js
@@ -1,7 +1,7 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/ui/submit-button";
 import ManageLearnings from "@/components/admin/manage-learnings";
 import ManageTutorials from "@/components/admin/manage-tutorials";
 import ManageUsers from "@/components/admin/manage-users";
@@ -21,9 +21,9 @@ export default async function AdminPage() {
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Welcome Admin!</h1>
         <form action={logout}>
-          <Button type="submit" variant="secondary">
+          <SubmitButton type="submit" variant="secondary" pendingText="Logging out...">
             Logout
-          </Button>
+          </SubmitButton>
         </form>
       </div>
       <Tabs defaultValue="learnings" className="w-full">

--- a/app/page.js
+++ b/app/page.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { useFormState } from 'react-dom';
+import { useActionState } from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Input } from "@/components/ui/input";
@@ -11,8 +11,14 @@ import { loginAdmin, loginUser } from "./actions";
 const initialState = { errors: {} };
 
 export default function Home() {
-  const [userState, userAction] = useFormState(loginUser, initialState);
-  const [adminState, adminAction] = useFormState(loginAdmin, initialState);
+  const [userState, userAction, userPending] = useActionState(
+    loginUser,
+    initialState
+  );
+  const [adminState, adminAction, adminPending] = useActionState(
+    loginAdmin,
+    initialState
+  );
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center p-4 space-y-6">
@@ -63,7 +69,9 @@ export default function Home() {
                   <p className="text-sm text-center text-red-500">{userState.errors.general}</p>
                 )}
                 <div className="flex justify-center">
-                  <Button type="submit">Login</Button>
+                  <Button type="submit" disabled={userPending}>
+                    {userPending ? "Loading..." : "Login"}
+                  </Button>
                 </div>
               </form>
             </TabsContent>
@@ -103,7 +111,9 @@ export default function Home() {
                   <p className="text-sm text-center text-red-500">{adminState.errors.general}</p>
                 )}
                 <div className="flex justify-center">
-                  <Button type="submit">Login</Button>
+                  <Button type="submit" disabled={adminPending}>
+                    {adminPending ? "Loading..." : "Login"}
+                  </Button>
                 </div>
               </form>
             </TabsContent>

--- a/components/admin/manage-learnings.js
+++ b/components/admin/manage-learnings.js
@@ -1,6 +1,10 @@
 import { prisma } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import { writeFile, mkdir } from "fs/promises";
+import { join } from "path";
+import { randomUUID } from "crypto";
 import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/ui/submit-button";
 import {
   Dialog,
   DialogTrigger,
@@ -15,7 +19,18 @@ async function addModule(formData) {
   "use server";
   const name = formData.get("name");
   const description = formData.get("description");
-  await prisma.learningModule.create({ data: { name, description, fileUrl: "" } });
+  const file = formData.get("file");
+  let fileUrl = "";
+  if (file && typeof file === "object") {
+    const bytes = await file.arrayBuffer();
+    const buffer = Buffer.from(bytes);
+    const fileName = `${randomUUID()}-${file.name}`;
+    const dir = join(process.cwd(), "public", "uploads");
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, fileName), buffer);
+    fileUrl = `/uploads/${fileName}`;
+  }
+  await prisma.learningModule.create({ data: { name, description, fileUrl } });
   revalidatePath("/admin");
 }
 
@@ -46,14 +61,34 @@ export default async function ManageLearnings() {
             </DialogHeader>
             <form action={addModule} className="space-y-4">
               <div className="space-y-2">
-                <Label htmlFor="module-name">Module Name</Label>
-                <Input id="module-name" name="name" required />
+                <Label htmlFor="module-name">
+                  Module Name <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="module-name"
+                  name="name"
+                  placeholder="Enter module name"
+                  required
+                />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="module-desc">Description</Label>
-                <Input id="module-desc" name="description" required />
+                <Label htmlFor="module-desc">
+                  Description <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="module-desc"
+                  name="description"
+                  placeholder="Describe module"
+                  required
+                />
               </div>
-              <Button type="submit">Save</Button>
+              <div className="space-y-2">
+                <Label htmlFor="module-file">
+                  PDF <span className="text-red-500">*</span>
+                </Label>
+                <Input id="module-file" name="file" type="file" accept="application/pdf" required />
+              </div>
+              <SubmitButton type="submit" pendingText="Saving...">Save</SubmitButton>
             </form>
           </DialogContent>
         </Dialog>
@@ -64,13 +99,15 @@ export default async function ManageLearnings() {
             <div className="flex items-center justify-between">
               <h3 className="font-medium">{m.name}</h3>
               <div className="flex gap-2">
-                <form action={async () => toggleModule(m.id, !m.active)}>
-                  <Button type="submit" variant="secondary">
+                <form action={toggleModule.bind(null, m.id, !m.active)}>
+                  <SubmitButton type="submit" variant="secondary" pendingText="Updating...">
                     {m.active ? "Deactivate" : "Activate"}
-                  </Button>
+                  </SubmitButton>
                 </form>
-                <form action={async () => deleteModule(m.id)}>
-                  <Button type="submit" variant="ghost">Delete</Button>
+                <form action={deleteModule.bind(null, m.id)}>
+                  <SubmitButton type="submit" variant="ghost" pendingText="Deleting...">
+                    Delete
+                  </SubmitButton>
                 </form>
               </div>
             </div>

--- a/components/admin/manage-tutorials.js
+++ b/components/admin/manage-tutorials.js
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/ui/submit-button";
 import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -50,18 +51,39 @@ export default async function ManageTutorials() {
             </DialogHeader>
             <form action={addTutorial} className="space-y-4">
               <div className="space-y-2">
-                <Label htmlFor="tut-name">Tutorial Name</Label>
-                <Input id="tut-name" name="name" required />
+                <Label htmlFor="tut-name">
+                  Tutorial Name <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="tut-name"
+                  name="name"
+                  placeholder="Enter tutorial name"
+                  required
+                />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="tut-desc">Description</Label>
-                <Input id="tut-desc" name="description" required />
+                <Label htmlFor="tut-desc">
+                  Description <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="tut-desc"
+                  name="description"
+                  placeholder="Describe tutorial"
+                  required
+                />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="tut-url">YouTube Link</Label>
-                <Input id="tut-url" name="youtubeUrl" required />
+                <Label htmlFor="tut-url">
+                  YouTube Link <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="tut-url"
+                  name="youtubeUrl"
+                  placeholder="https://youtube.com/watch?v=..."
+                  required
+                />
               </div>
-              <Button type="submit">Save</Button>
+              <SubmitButton type="submit" pendingText="Saving...">Save</SubmitButton>
             </form>
           </DialogContent>
         </Dialog>
@@ -74,13 +96,15 @@ export default async function ManageTutorials() {
               <div className="flex items-center justify-between">
                 <h3 className="font-medium">{t.name}</h3>
                 <div className="flex gap-2">
-                  <form action={async () => toggleTutorial(t.id, !t.active)}>
-                    <Button type="submit" variant="secondary">
+                  <form action={toggleTutorial.bind(null, t.id, !t.active)}>
+                    <SubmitButton type="submit" variant="secondary" pendingText="Updating...">
                       {t.active ? "Deactivate" : "Activate"}
-                    </Button>
+                    </SubmitButton>
                   </form>
-                  <form action={async () => deleteTutorial(t.id)}>
-                    <Button type="submit" variant="ghost">Delete</Button>
+                  <form action={deleteTutorial.bind(null, t.id)}>
+                    <SubmitButton type="submit" variant="ghost" pendingText="Deleting...">
+                      Delete
+                    </SubmitButton>
                   </form>
                 </div>
               </div>

--- a/components/admin/manage-users.js
+++ b/components/admin/manage-users.js
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/ui/submit-button";
 import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogClose } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -61,16 +62,42 @@ export default async function ManageUsers() {
             </DialogHeader>
             <form action={addUser} className="space-y-4">
               <div className="space-y-2">
-                <Label htmlFor="user-name">Name</Label>
-                <Input id="user-name" name="name" required />
+                <Label htmlFor="user-name">
+                  Name <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="user-name"
+                  name="name"
+                  placeholder="Enter name"
+                  required
+                />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="user-email">Email</Label>
-                <Input id="user-email" name="email" type="email" required />
+                <Label htmlFor="user-email">
+                  Email <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="user-email"
+                  name="email"
+                  type="email"
+                  placeholder="Enter email"
+                  required
+                />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="user-membership">Membership Taken</Label>
-                <select id="user-membership" name="membership" className="w-full rounded-md border px-3 py-2 text-sm" required>
+                <Label htmlFor="user-membership">
+                  Membership Taken <span className="text-red-500">*</span>
+                </Label>
+                <select
+                  id="user-membership"
+                  name="membership"
+                  className="w-full rounded-md border px-3 py-2 text-sm"
+                  required
+                  defaultValue=""
+                >
+                  <option value="" disabled>
+                    Select membership
+                  </option>
                   <option value="SILVER">Silver</option>
                   <option value="GOLD">Gold</option>
                   <option value="DIAMOND">Diamond</option>
@@ -79,15 +106,31 @@ export default async function ManageUsers() {
               </div>
               <div className="flex gap-4">
                 <div className="space-y-2 flex-1">
-                  <Label htmlFor="startDate">Start Date</Label>
-                  <Input id="startDate" name="startDate" type="date" required />
+                  <Label htmlFor="startDate">
+                    Start Date <span className="text-red-500">*</span>
+                  </Label>
+                  <Input
+                    id="startDate"
+                    name="startDate"
+                    type="date"
+                    placeholder="Select start date"
+                    required
+                  />
                 </div>
                 <div className="space-y-2 flex-1">
-                  <Label htmlFor="endDate">End Date</Label>
-                  <Input id="endDate" name="endDate" type="date" required />
+                  <Label htmlFor="endDate">
+                    End Date <span className="text-red-500">*</span>
+                  </Label>
+                  <Input
+                    id="endDate"
+                    name="endDate"
+                    type="date"
+                    placeholder="Select end date"
+                    required
+                  />
                 </div>
               </div>
-              <Button type="submit">Save</Button>
+              <SubmitButton type="submit" pendingText="Saving...">Save</SubmitButton>
             </form>
           </DialogContent>
         </Dialog>
@@ -126,11 +169,15 @@ export default async function ManageUsers() {
               </div>
             </div>
             <div className="flex gap-2">
-              <form action={async () => deactivateUser(u.id)}>
-                <Button type="submit" variant="secondary">Deactivate</Button>
+              <form action={deactivateUser.bind(null, u.id)}>
+                <SubmitButton type="submit" variant="secondary" pendingText="Updating...">
+                  Deactivate
+                </SubmitButton>
               </form>
-              <form action={async () => deleteUser(u.id)}>
-                <Button type="submit" variant="ghost">Delete</Button>
+              <form action={deleteUser.bind(null, u.id)}>
+                <SubmitButton type="submit" variant="ghost" pendingText="Deleting...">
+                  Delete
+                </SubmitButton>
               </form>
             </div>
           </div>

--- a/components/ui/submit-button.js
+++ b/components/ui/submit-button.js
@@ -1,0 +1,13 @@
+"use client";
+
+import { useFormStatus } from "react-dom";
+import { Button } from "./button";
+
+export function SubmitButton({ children, pendingText = "Loading...", ...props }) {
+  const { pending } = useFormStatus();
+  return (
+    <Button {...props} disabled={pending}>
+      {pending ? pendingText : children}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- switch to `useActionState` and show loading feedback on login
- add reusable `SubmitButton` with form pending states
- support PDF uploads for learning modules and add placeholders and required markers across forms

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b453d463948323aa51c071293bd249