### PR TITLE
Add button loading states and module PDF upload

### DIFF
--- a/app/admin/page.js
+++ b/app/admin/page.js
@@ -1,7 +1,7 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/ui/submit-button";
 import ManageLearnings from "@/components/admin/manage-learnings";
 import ManageTutorials from "@/components/admin/manage-tutorials";
 import ManageUsers from "@/components/admin/manage-users";
@@ -21,9 +21,9 @@ export default async function AdminPage() {
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Welcome Admin!</h1>
         <form action={logout}>
-          <Button type="submit" variant="secondary">
+          <SubmitButton type="submit" variant="secondary" pendingText="Logging out...">
             Logout
-          </Button>
+          </SubmitButton>
         </form>
       </div>
       <Tabs defaultValue="learnings" className="w-full">

--- a/app/page.js
+++ b/app/page.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { useFormState } from 'react-dom';
+import { useActionState } from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Input } from "@/components/ui/input";
@@ -11,14 +11,20 @@ import { loginAdmin, loginUser } from "./actions";
 const initialState = { errors: {} };
 
 export default function Home() {
-  const [userState, userAction] = useFormState(loginUser, initialState);
-  const [adminState, adminAction] = useFormState(loginAdmin, initialState);
+  const [userState, userAction, userPending] = useActionState(
+    loginUser,
+    initialState
+  );
+  const [adminState, adminAction, adminPending] = useActionState(
+    loginAdmin,
+    initialState
+  );
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center p-4 space-y-6">
       <h1 className="text-2xl font-bold">FTC Consulting Management Platform</h1>
       <Card className="w-full max-w-md">
-        <CardHeader>
+        <CardHeader className="text-center">
           <CardTitle>Login</CardTitle>
         </CardHeader>
         <CardContent>
@@ -63,7 +69,9 @@ export default function Home() {
                   <p className="text-sm text-center text-red-500">{userState.errors.general}</p>
                 )}
                 <div className="flex justify-center">
-                  <Button type="submit">Login</Button>
+                  <Button type="submit" disabled={userPending}>
+                    {userPending ? "Loading..." : "Login"}
+                  </Button>
                 </div>
               </form>
             </TabsContent>
@@ -103,7 +111,9 @@ export default function Home() {
                   <p className="text-sm text-center text-red-500">{adminState.errors.general}</p>
                 )}
                 <div className="flex justify-center">
-                  <Button type="submit">Login</Button>
+                  <Button type="submit" disabled={adminPending}>
+                    {adminPending ? "Loading..." : "Login"}
+                  </Button>
                 </div>
               </form>
             </TabsContent>

--- a/components/admin/add-learning-module-dialog.js
+++ b/components/admin/add-learning-module-dialog.js
@@ -1,0 +1,79 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/ui/submit-button";
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { X } from "lucide-react";
+import { addModule } from "@/lib/learning-modules";
+
+export default function AddLearningModuleDialog() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>Add Module</Button>
+      </DialogTrigger>
+      <DialogContent
+        className="rounded-lg"
+        onInteractOutside={(e) => e.preventDefault()}
+      >
+        <DialogHeader className="flex flex-row items-center justify-between">
+          <DialogTitle>New Module</DialogTitle>
+          <DialogClose className="cursor-pointer rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none">
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </DialogClose>
+        </DialogHeader>
+        <form
+          action={addModule}
+          className="space-y-4"
+          encType="multipart/form-data"
+        >
+          <div className="space-y-2">
+            <Label htmlFor="module-name">
+              Module Name <span className="text-red-500">*</span>
+            </Label>
+            <Input
+              id="module-name"
+              name="name"
+              placeholder="Enter module name"
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="module-desc">Description</Label>
+            <Input
+              id="module-desc"
+              name="description"
+              placeholder="Describe module"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="module-file">
+              PDF (max 50MB) <span className="text-red-500">*</span>
+            </Label>
+            <Input
+              id="module-file"
+              name="file"
+              type="file"
+              accept="application/pdf"
+              required
+            />
+          </div>
+          <DialogClose asChild>
+            <SubmitButton type="submit" pendingText="Saving...">Save</SubmitButton>
+          </DialogClose>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/components/admin/learning-module-card.js
+++ b/components/admin/learning-module-card.js
@@ -1,0 +1,103 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/ui/submit-button";
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Eye, Download, Trash, X } from "lucide-react";
+import { toggleModule, deleteModule } from "@/lib/learning-modules";
+
+export default function LearningModuleCard({ module }) {
+  const { id, name, description, fileUrl, active } = module;
+  return (
+    <div className="flex items-start justify-between rounded border p-4">
+      <div className="pr-4">
+        <h3 className="font-medium">{name}</h3>
+        {description && (
+          <p className="text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        {fileUrl && (
+          <>
+            <Dialog>
+              <DialogTrigger asChild>
+                <Button variant="ghost" size="icon" title="View">
+                  <Eye className="h-4 w-4" />
+                </Button>
+              </DialogTrigger>
+              <DialogContent
+                className="max-w-3xl rounded-lg"
+                onInteractOutside={(e) => e.preventDefault()}
+              >
+                <DialogHeader className="flex flex-row items-center justify-between">
+                  <DialogTitle>{name}</DialogTitle>
+                  <DialogClose className="cursor-pointer rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none">
+                    <X className="h-4 w-4" />
+                    <span className="sr-only">Close</span>
+                  </DialogClose>
+                </DialogHeader>
+                <iframe src={fileUrl} className="h-[75vh] w-full" />
+              </DialogContent>
+            </Dialog>
+            <a href={fileUrl} download target="_blank">
+              <Button variant="ghost" size="icon" title="Download">
+                <Download className="h-4 w-4" />
+              </Button>
+            </a>
+          </>
+        )}
+        <form action={toggleModule.bind(null, id, !active)}>
+          <SubmitButton
+            type="submit"
+            variant="secondary"
+            pendingText="Updating..."
+          >
+            {active ? "Deactivate" : "Activate"}
+          </SubmitButton>
+        </form>
+        <DeleteModuleButton id={id} />
+      </div>
+    </div>
+  );
+}
+
+function DeleteModuleButton({ id }) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="icon" title="Delete">
+          <Trash className="h-4 w-4" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent
+        className="rounded-lg"
+        onInteractOutside={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>Delete module?</DialogTitle>
+        </DialogHeader>
+        <form
+          action={deleteModule.bind(null, id)}
+          className="flex justify-end gap-2"
+        >
+          <DialogClose asChild>
+            <Button type="button" variant="secondary">
+              Cancel
+            </Button>
+          </DialogClose>
+          <SubmitButton type="submit" pendingText="Deleting...">
+            Delete
+          </SubmitButton>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/components/admin/manage-learnings.js
+++ b/components/admin/manage-learnings.js
@@ -1,81 +1,17 @@
 import { prisma } from "@/lib/prisma";
-import { revalidatePath } from "next/cache";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogTrigger,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-
-async function addModule(formData) {
-  "use server";
-  const name = formData.get("name");
-  const description = formData.get("description");
-  await prisma.learningModule.create({ data: { name, description, fileUrl: "" } });
-  revalidatePath("/admin");
-}
-
-async function toggleModule(id, active) {
-  "use server";
-  await prisma.learningModule.update({ where: { id }, data: { active } });
-  revalidatePath("/admin");
-}
-
-async function deleteModule(id) {
-  "use server";
-  await prisma.learningModule.delete({ where: { id } });
-  revalidatePath("/admin");
-}
+import AddLearningModuleDialog from "./add-learning-module-dialog";
+import LearningModuleCard from "./learning-module-card";
 
 export default async function ManageLearnings() {
   const modules = await prisma.learningModule.findMany({ orderBy: { id: "desc" } });
   return (
     <div className="space-y-4">
       <div className="flex justify-end">
-        <Dialog>
-          <DialogTrigger asChild>
-            <Button>Add Module</Button>
-          </DialogTrigger>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>New Module</DialogTitle>
-            </DialogHeader>
-            <form action={addModule} className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="module-name">Module Name</Label>
-                <Input id="module-name" name="name" required />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="module-desc">Description</Label>
-                <Input id="module-desc" name="description" required />
-              </div>
-              <Button type="submit">Save</Button>
-            </form>
-          </DialogContent>
-        </Dialog>
+        <AddLearningModuleDialog />
       </div>
-      <div className="grid gap-4 md:grid-cols-2">
+      <div className="space-y-4">
         {modules.map((m) => (
-          <div key={m.id} className="rounded border p-4 space-y-2">
-            <div className="flex items-center justify-between">
-              <h3 className="font-medium">{m.name}</h3>
-              <div className="flex gap-2">
-                <form action={async () => toggleModule(m.id, !m.active)}>
-                  <Button type="submit" variant="secondary">
-                    {m.active ? "Deactivate" : "Activate"}
-                  </Button>
-                </form>
-                <form action={async () => deleteModule(m.id)}>
-                  <Button type="submit" variant="ghost">Delete</Button>
-                </form>
-              </div>
-            </div>
-            <p className="text-sm text-muted-foreground">{m.description}</p>
-          </div>
+          <LearningModuleCard key={m.id} module={m} />
         ))}
         {modules.length === 0 && <p>No modules uploaded.</p>}
       </div>

--- a/components/admin/manage-tutorials.js
+++ b/components/admin/manage-tutorials.js
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/ui/submit-button";
 import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -50,18 +51,39 @@ export default async function ManageTutorials() {
             </DialogHeader>
             <form action={addTutorial} className="space-y-4">
               <div className="space-y-2">
-                <Label htmlFor="tut-name">Tutorial Name</Label>
-                <Input id="tut-name" name="name" required />
+                <Label htmlFor="tut-name">
+                  Tutorial Name <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="tut-name"
+                  name="name"
+                  placeholder="Enter tutorial name"
+                  required
+                />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="tut-desc">Description</Label>
-                <Input id="tut-desc" name="description" required />
+                <Label htmlFor="tut-desc">
+                  Description <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="tut-desc"
+                  name="description"
+                  placeholder="Describe tutorial"
+                  required
+                />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="tut-url">YouTube Link</Label>
-                <Input id="tut-url" name="youtubeUrl" required />
+                <Label htmlFor="tut-url">
+                  YouTube Link <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="tut-url"
+                  name="youtubeUrl"
+                  placeholder="https://youtube.com/watch?v=..."
+                  required
+                />
               </div>
-              <Button type="submit">Save</Button>
+              <SubmitButton type="submit" pendingText="Saving...">Save</SubmitButton>
             </form>
           </DialogContent>
         </Dialog>
@@ -74,13 +96,15 @@ export default async function ManageTutorials() {
               <div className="flex items-center justify-between">
                 <h3 className="font-medium">{t.name}</h3>
                 <div className="flex gap-2">
-                  <form action={async () => toggleTutorial(t.id, !t.active)}>
-                    <Button type="submit" variant="secondary">
+                  <form action={toggleTutorial.bind(null, t.id, !t.active)}>
+                    <SubmitButton type="submit" variant="secondary" pendingText="Updating...">
                       {t.active ? "Deactivate" : "Activate"}
-                    </Button>
+                    </SubmitButton>
                   </form>
-                  <form action={async () => deleteTutorial(t.id)}>
-                    <Button type="submit" variant="ghost">Delete</Button>
+                  <form action={deleteTutorial.bind(null, t.id)}>
+                    <SubmitButton type="submit" variant="ghost" pendingText="Deleting...">
+                      Delete
+                    </SubmitButton>
                   </form>
                 </div>
               </div>

--- a/components/admin/manage-users.js
+++ b/components/admin/manage-users.js
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/ui/submit-button";
 import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogClose } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -61,16 +62,42 @@ export default async function ManageUsers() {
             </DialogHeader>
             <form action={addUser} className="space-y-4">
               <div className="space-y-2">
-                <Label htmlFor="user-name">Name</Label>
-                <Input id="user-name" name="name" required />
+                <Label htmlFor="user-name">
+                  Name <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="user-name"
+                  name="name"
+                  placeholder="Enter name"
+                  required
+                />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="user-email">Email</Label>
-                <Input id="user-email" name="email" type="email" required />
+                <Label htmlFor="user-email">
+                  Email <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="user-email"
+                  name="email"
+                  type="email"
+                  placeholder="Enter email"
+                  required
+                />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="user-membership">Membership Taken</Label>
-                <select id="user-membership" name="membership" className="w-full rounded-md border px-3 py-2 text-sm" required>
+                <Label htmlFor="user-membership">
+                  Membership Taken <span className="text-red-500">*</span>
+                </Label>
+                <select
+                  id="user-membership"
+                  name="membership"
+                  className="w-full rounded-md border px-3 py-2 text-sm"
+                  required
+                  defaultValue=""
+                >
+                  <option value="" disabled>
+                    Select membership
+                  </option>
                   <option value="SILVER">Silver</option>
                   <option value="GOLD">Gold</option>
                   <option value="DIAMOND">Diamond</option>
@@ -79,15 +106,31 @@ export default async function ManageUsers() {
               </div>
               <div className="flex gap-4">
                 <div className="space-y-2 flex-1">
-                  <Label htmlFor="startDate">Start Date</Label>
-                  <Input id="startDate" name="startDate" type="date" required />
+                  <Label htmlFor="startDate">
+                    Start Date <span className="text-red-500">*</span>
+                  </Label>
+                  <Input
+                    id="startDate"
+                    name="startDate"
+                    type="date"
+                    placeholder="Select start date"
+                    required
+                  />
                 </div>
                 <div className="space-y-2 flex-1">
-                  <Label htmlFor="endDate">End Date</Label>
-                  <Input id="endDate" name="endDate" type="date" required />
+                  <Label htmlFor="endDate">
+                    End Date <span className="text-red-500">*</span>
+                  </Label>
+                  <Input
+                    id="endDate"
+                    name="endDate"
+                    type="date"
+                    placeholder="Select end date"
+                    required
+                  />
                 </div>
               </div>
-              <Button type="submit">Save</Button>
+              <SubmitButton type="submit" pendingText="Saving...">Save</SubmitButton>
             </form>
           </DialogContent>
         </Dialog>
@@ -126,11 +169,15 @@ export default async function ManageUsers() {
               </div>
             </div>
             <div className="flex gap-2">
-              <form action={async () => deactivateUser(u.id)}>
-                <Button type="submit" variant="secondary">Deactivate</Button>
+              <form action={deactivateUser.bind(null, u.id)}>
+                <SubmitButton type="submit" variant="secondary" pendingText="Updating...">
+                  Deactivate
+                </SubmitButton>
               </form>
-              <form action={async () => deleteUser(u.id)}>
-                <Button type="submit" variant="ghost">Delete</Button>
+              <form action={deleteUser.bind(null, u.id)}>
+                <SubmitButton type="submit" variant="ghost" pendingText="Deleting...">
+                  Delete
+                </SubmitButton>
               </form>
             </div>
           </div>

--- a/components/ui/submit-button.js
+++ b/components/ui/submit-button.js
@@ -1,0 +1,13 @@
+"use client";
+
+import { useFormStatus } from "react-dom";
+import { Button } from "./button";
+
+export function SubmitButton({ children, pendingText = "Loading...", ...props }) {
+  const { pending } = useFormStatus();
+  return (
+    <Button {...props} disabled={pending}>
+      {pending ? pendingText : children}
+    </Button>
+  );
+}

--- a/lib/learning-modules.js
+++ b/lib/learning-modules.js
@@ -1,0 +1,41 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+import { revalidatePath } from "next/cache";
+import { writeFile, mkdir } from "fs/promises";
+import { join } from "path";
+import { randomUUID } from "crypto";
+
+const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
+
+export async function addModule(formData) {
+  const name = formData.get("name");
+  const description = formData.get("description");
+  const file = formData.get("file");
+  let fileUrl = "";
+  if (file && typeof file === "object") {
+    if (file.size > MAX_FILE_SIZE) {
+      throw new Error("File size exceeds 50MB limit");
+    }
+    const bytes = await file.arrayBuffer();
+    const buffer = Buffer.from(bytes);
+    const fileName = `${randomUUID()}-${file.name}`;
+    const dir = join(process.cwd(), "public", "uploads");
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, fileName), buffer);
+    fileUrl = `/uploads/${fileName}`;
+  }
+  await prisma.learningModule.create({ data: { name, description, fileUrl } });
+  revalidatePath("/admin");
+}
+
+export async function toggleModule(id, active) {
+  await prisma.learningModule.update({ where: { id }, data: { active } });
+  revalidatePath("/admin");
+}
+
+export async function deleteModule(id) {
+  await prisma.learningModule.delete({ where: { id } });
+  revalidatePath("/admin");
+}
+

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,10 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "50mb",
+    },
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- switch to `useActionState` and show loading feedback on login
- add reusable `SubmitButton` with form pending states
- support PDF uploads for learning modules with a 50MB cap, round the modal with an explicit close button, and make module descriptions optional
- refactor learning module dialog into a client component and isolate server actions to prevent server/client boundary errors
- center the login card title
- mark learning-module helpers as a server-only module so actions can be imported without build failures
- list learning modules in horizontal cards with in-app PDF preview, download links, activation toggles, and delete-confirmation dialogs
- make modal close icons use a pointer cursor

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b453d463948323aa51c071293bd249