### PR TITLE
Persist learning module files in database

### DIFF
--- a/app/api/modules/[id]/file/route.js
+++ b/app/api/modules/[id]/file/route.js
@@ -1,0 +1,21 @@
+import { prisma } from "@/lib/prisma";
+
+export async function GET(req, { params }) {
+  const id = Number(params.id);
+  if (Number.isNaN(id)) {
+    return new Response("Invalid id", { status: 400 });
+  }
+  const learningModule = await prisma.learningModule.findUnique({
+    where: { id },
+    select: { file: true },
+  });
+  if (!learningModule || !learningModule.file) {
+    return new Response("Not found", { status: 404 });
+  }
+  return new Response(learningModule.file, {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": "inline",
+    },
+  });
+}

--- a/components/admin/learning-module-card.js
+++ b/components/admin/learning-module-card.js
@@ -14,7 +14,8 @@ import { Eye, Download, Trash, X } from "lucide-react";
 import { toggleModule, deleteModule } from "@/lib/learning-modules";
 
 export default function LearningModuleCard({ module }) {
-  const { id, name, description, fileUrl, active } = module;
+  const { id, name, description, active } = module;
+  const fileUrl = `/api/modules/${id}/file`;
   return (
     <div className="flex items-start justify-between rounded border p-4">
       <div className="pr-4">
@@ -24,35 +25,31 @@ export default function LearningModuleCard({ module }) {
         )}
       </div>
       <div className="flex items-center gap-2">
-        {fileUrl && (
-          <>
-            <Dialog>
-              <DialogTrigger asChild>
-                <Button variant="ghost" size="icon" title="View">
-                  <Eye className="h-4 w-4" />
-                </Button>
-              </DialogTrigger>
-              <DialogContent
-                className="max-w-3xl rounded-lg"
-                onInteractOutside={(e) => e.preventDefault()}
-              >
-                <DialogHeader className="flex flex-row items-center justify-between">
-                  <DialogTitle>{name}</DialogTitle>
-                  <DialogClose className="cursor-pointer rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none">
-                    <X className="h-4 w-4" />
-                    <span className="sr-only">Close</span>
-                  </DialogClose>
-                </DialogHeader>
-                <iframe src={fileUrl} className="h-[75vh] w-full" />
-              </DialogContent>
-            </Dialog>
-            <a href={fileUrl} download target="_blank">
-              <Button variant="ghost" size="icon" title="Download">
-                <Download className="h-4 w-4" />
-              </Button>
-            </a>
-          </>
-        )}
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button variant="ghost" size="icon" title="View">
+              <Eye className="h-4 w-4" />
+            </Button>
+          </DialogTrigger>
+          <DialogContent
+            className="max-w-3xl rounded-lg"
+            onInteractOutside={(e) => e.preventDefault()}
+          >
+            <DialogHeader className="flex flex-row items-center justify-between">
+              <DialogTitle>{name}</DialogTitle>
+              <DialogClose className="cursor-pointer rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none">
+                <X className="h-4 w-4" />
+                <span className="sr-only">Close</span>
+              </DialogClose>
+            </DialogHeader>
+            <iframe src={fileUrl} className="h-[75vh] w-full" />
+          </DialogContent>
+        </Dialog>
+        <a href={fileUrl} download target="_blank">
+          <Button variant="ghost" size="icon" title="Download">
+            <Download className="h-4 w-4" />
+          </Button>
+        </a>
         <form action={toggleModule.bind(null, id, !active)}>
           <SubmitButton
             type="submit"

--- a/components/admin/manage-learnings.js
+++ b/components/admin/manage-learnings.js
@@ -3,7 +3,10 @@ import AddLearningModuleDialog from "./add-learning-module-dialog";
 import LearningModuleCard from "./learning-module-card";
 
 export default async function ManageLearnings() {
-  const modules = await prisma.learningModule.findMany({ orderBy: { id: "desc" } });
+  const modules = await prisma.learningModule.findMany({
+    orderBy: { id: "desc" },
+    select: { id: true, name: true, description: true, active: true },
+  });
   return (
     <div className="space-y-4">
       <div className="flex justify-end">

--- a/lib/learning-modules.js
+++ b/lib/learning-modules.js
@@ -2,30 +2,24 @@
 
 import { prisma } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
-import { writeFile, mkdir } from "fs/promises";
-import { join } from "path";
-import { randomUUID } from "crypto";
-
 const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 
 export async function addModule(formData) {
   const name = formData.get("name");
-  const description = formData.get("description");
+  const description = formData.get("description") || "";
   const file = formData.get("file");
-  let fileUrl = "";
+  let fileBuffer = null;
   if (file && typeof file === "object") {
     if (file.size > MAX_FILE_SIZE) {
       throw new Error("File size exceeds 50MB limit");
     }
     const bytes = await file.arrayBuffer();
-    const buffer = Buffer.from(bytes);
-    const fileName = `${randomUUID()}-${file.name}`;
-    const dir = join(process.cwd(), "public", "uploads");
-    await mkdir(dir, { recursive: true });
-    await writeFile(join(dir, fileName), buffer);
-    fileUrl = `/uploads/${fileName}`;
+    fileBuffer = Buffer.from(bytes);
   }
-  await prisma.learningModule.create({ data: { name, description, fileUrl } });
+  if (!fileBuffer) {
+    throw new Error("File is required");
+  }
+  await prisma.learningModule.create({ data: { name, description, file: fileBuffer } });
   revalidatePath("/admin");
 }
 

--- a/prisma/migrations/20250510120000_add_file_column/migration.sql
+++ b/prisma/migrations/20250510120000_add_file_column/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "public"."LearningModule" ADD COLUMN "file" BYTEA NOT NULL;
+ALTER TABLE "public"."LearningModule" DROP COLUMN "fileUrl";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,7 +41,7 @@ model LearningModule {
   id          Int      @id @default(autoincrement())
   name        String
   description String
-  fileUrl     String
+  file        Bytes
   active      Boolean  @default(true)
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt


### PR DESCRIPTION
## Summary
- Store uploaded learning module PDFs directly in the database via a new `file` field.
- Load modules without file blobs and serve PDF content through a new `/api/modules/[id]/file` route.
- Update admin UI to use database-stored files when viewing or downloading modules.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_68b489848e308323a5735d67ef4cf791