### PR TITLE
Fix learning module uploads

### DIFF
--- a/components/admin/add-learning-module-dialog.js
+++ b/components/admin/add-learning-module-dialog.js
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { SubmitButton } from "@/components/ui/submit-button";
 import {
@@ -16,8 +17,15 @@ import { X } from "lucide-react";
 import { addModule } from "@/lib/learning-modules";
 
 export default function AddLearningModuleDialog() {
+  const [open, setOpen] = useState(false);
+
+  async function handleSubmit(formData) {
+    await addModule(formData);
+    setOpen(false);
+  }
+
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button>Add Module</Button>
       </DialogTrigger>
@@ -33,7 +41,7 @@ export default function AddLearningModuleDialog() {
           </DialogClose>
         </DialogHeader>
         <form
-          action={addModule}
+          action={handleSubmit}
           className="space-y-4"
           encType="multipart/form-data"
         >
@@ -68,9 +76,9 @@ export default function AddLearningModuleDialog() {
               required
             />
           </div>
-          <DialogClose asChild>
-            <SubmitButton type="submit" pendingText="Saving...">Save</SubmitButton>
-          </DialogClose>
+          <SubmitButton type="submit" pendingText="Saving...">
+            Save
+          </SubmitButton>
         </form>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary
- ensure Add Module dialog submits form data before closing
- close dialog after module creation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b49b5cc3e0832397b7b6110c183a9c