### PR TITLE
feat: add phone field and improve login

### DIFF
--- a/app/actions.js
+++ b/app/actions.js
@@ -53,6 +53,10 @@ export async function loginUser(prevState, formData) {
   if (!user) return { errors: { general: "Invalid credentials" }, success: false };
   const valid = await bcrypt.compare(password, user.password);
   if (!valid) return { errors: { general: "Invalid credentials" }, success: false };
+  const today = new Date();
+  if (user.status !== "ACTIVE" || user.endDate < today) {
+    return { errors: { general: "Membership Expired" }, success: false };
+  }
   cookies().set("userId", String(user.id), { path: "/" });
   await prisma.user.update({
     where: { id: user.id },

--- a/app/page.js
+++ b/app/page.js
@@ -66,9 +66,11 @@ export default function Home() {
         height={200}
         className="mb-4"
       />
-      <h1 className="text-xl text-center sm:text-2xl font-heading font-bold">
-        FTC Consulting Management Platform
-      </h1>
+      <div className="w-full max-w-md text-center">
+        <h1 className="text-lg sm:text-2xl font-heading font-bold">
+          FTC Consulting Management Platform
+        </h1>
+      </div>
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
           <CardTitle>Login</CardTitle>

--- a/components/admin/add-user-dialog.js
+++ b/components/admin/add-user-dialog.js
@@ -59,6 +59,18 @@ export default function AddUserDialog() {
             <Input id="user-email" name="email" type="email" placeholder="Enter email" required />
           </div>
           <div className="space-y-2">
+            <Label htmlFor="user-phone">
+              Phone Number <span className="text-red-500">*</span>
+            </Label>
+            <Input
+              id="user-phone"
+              name="phone"
+              type="tel"
+              placeholder="Enter phone number"
+              required
+            />
+          </div>
+          <div className="space-y-2">
             <Label htmlFor="user-membership">
               Membership Taken <span className="text-red-500">*</span>
             </Label>

--- a/lib/users.js
+++ b/lib/users.js
@@ -11,6 +11,7 @@ function generatePassword() {
 export async function addUser(formData) {
   const name = formData.get("name");
   const email = formData.get("email");
+  const phone = formData.get("phone");
   const membership = formData.get("membership");
   const startDate = new Date(formData.get("startDate"));
   const endDate = new Date(formData.get("endDate"));
@@ -20,6 +21,7 @@ export async function addUser(formData) {
     data: {
       name,
       email,
+      phone,
       membership,
       startDate,
       endDate,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,7 @@ model User {
   membership    Membership
   startDate     DateTime
   endDate       DateTime
+  phone         String?
   imageUrl      String?
   status        String      @default("CREATED")
   lastLogin     DateTime?


### PR DESCRIPTION
## Summary
- reduce login page heading size and center on mobile
- capture phone number when adding users and store in database
- prevent inactive or expired users from signing in

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9805febd48323bf46bc4058dd9c8f