### PR TITLE
Add phone column to Prisma User model

### DIFF
--- a/prisma/migrations/20250904123909_add_user_phone/migration.sql
+++ b/prisma/migrations/20250904123909_add_user_phone/migration.sql
@@ -1,0 +1,2 @@
+-- Add phone column to User table
+ALTER TABLE "public"."User" ADD COLUMN "phone" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,7 +6,6 @@
 
 generator client {
   provider = "prisma-client-js"
-  output   = "../lib/generated/prisma"
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- remove custom Prisma client output so generated client stays in node_modules
- add migration to introduce optional `phone` column on `User`

## Testing
- `npm run lint`
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_68b987e7ee348323ae70b109934a67b6