### PR TITLE
Wrap home page in Suspense for search params

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,11 +1,21 @@
 "use client";
 
-import { useActionState, useEffect } from "react";
+import { Suspense, useActionState, useEffect } from "react";
 import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+} from "@/components/ui/card";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from "@/components/ui/tabs";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
@@ -13,7 +23,7 @@ import { loginAdmin, loginUser } from "./actions";
 
 const initialState = { errors: {}, success: false };
 
-export default function Home() {
+function HomeContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [userState, userAction, userPending] = useActionState(
@@ -169,6 +179,14 @@ export default function Home() {
         </CardContent>
       </Card>
     </div>
+  );
+}
+
+export default function Home() {
+  return (
+    <Suspense fallback={null}>
+      <HomeContent />
+    </Suspense>
   );
 }
 


### PR DESCRIPTION
## Summary
- wrap home page content in a React Suspense boundary
- keep `useSearchParams` inside the suspense-wrapped component to satisfy Next.js

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` and `Roboto` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b99bcf54988323b3e60ffae47bc66f