### PR TITLE
feat: expand onboarding with business details and profile menu

### DIFF
--- a/app/user/onboarding/page.js
+++ b/app/user/onboarding/page.js
@@ -2,9 +2,7 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import { completeOnboarding } from "@/lib/users";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { SubmitButton } from "@/components/ui/submit-button";
+import OnboardingForm from "@/components/user/onboarding-form";
 
 export default async function OnboardingPage() {
   const userIdCookie = cookies().get("userId");
@@ -12,7 +10,14 @@ export default async function OnboardingPage() {
   const id = Number(userIdCookie.value);
   const user = await prisma.user.findUnique({ where: { id } });
   if (!user) redirect("/");
-  if (user.businessName || user.companyAddress || user.employeeCount !== null) {
+  if (
+    user.businessName &&
+    user.companyAddress &&
+    user.annualRevenue !== null &&
+    user.employeeCount !== null &&
+    user.manufacturing !== null &&
+    user.businessChallenges.length > 0
+  ) {
     redirect("/user");
   }
 
@@ -22,52 +27,15 @@ export default async function OnboardingPage() {
     redirect("/user");
   }
 
+  const formattedUser = {
+    ...user,
+    startDate: user.startDate.toISOString().split("T")[0],
+    endDate: user.endDate.toISOString().split("T")[0],
+  };
   return (
     <div className="max-w-xl mx-auto p-4 space-y-4">
       <h1 className="text-2xl font-heading font-bold text-center">Onboarding</h1>
-      <form action={handleSubmit} className="space-y-4" encType="multipart/form-data">
-        <div className="space-y-2">
-          <Label>Name</Label>
-          <Input defaultValue={user.name} disabled />
-        </div>
-        <div className="space-y-2">
-          <Label>Email</Label>
-          <Input defaultValue={user.email} disabled />
-        </div>
-        <div className="space-y-2">
-          <Label>Phone Number</Label>
-          <Input defaultValue={user.phone || ""} disabled />
-        </div>
-        <div className="space-y-2">
-          <Label>Membership Taken</Label>
-          <Input defaultValue={user.membership} disabled />
-        </div>
-        <div className="space-y-2">
-          <Label>Start Date</Label>
-          <Input defaultValue={user.startDate.toISOString().split("T")[0]} disabled />
-        </div>
-        <div className="space-y-2">
-          <Label>End Date</Label>
-          <Input defaultValue={user.endDate.toISOString().split("T")[0]} disabled />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="businessName">Business Name</Label>
-          <Input id="businessName" name="businessName" placeholder="Enter business name" />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="companyAddress">Company Address</Label>
-          <Input id="companyAddress" name="companyAddress" placeholder="Enter company address" />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="employeeCount">Total Employee Count</Label>
-          <Input id="employeeCount" name="employeeCount" type="number" placeholder="Enter total employees" />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="image">Profile Image</Label>
-          <Input id="image" name="image" type="file" accept="image/*" />
-        </div>
-        <SubmitButton type="submit" pendingText="Saving...">Save</SubmitButton>
-      </form>
+      <OnboardingForm user={formattedUser} action={handleSubmit} />
     </div>
   );
 }

--- a/app/user/page.js
+++ b/app/user/page.js
@@ -9,7 +9,14 @@ export default async function UserPage() {
   const id = Number(userIdCookie.value);
   const user = await prisma.user.findUnique({ where: { id } });
   if (!user) redirect("/");
-  if (!user.businessName || !user.companyAddress || user.employeeCount === null) {
+  if (
+    !user.businessName ||
+    !user.companyAddress ||
+    user.annualRevenue === null ||
+    user.employeeCount === null ||
+    user.manufacturing === null ||
+    user.businessChallenges.length === 0
+  ) {
     redirect("/user/onboarding");
   }
   const modules = await prisma.learningModule.findMany({

--- a/components/admin/add-user-dialog.js
+++ b/components/admin/add-user-dialog.js
@@ -71,6 +71,12 @@ export default function AddUserDialog() {
             />
           </div>
           <div className="space-y-2">
+            <Label htmlFor="user-business">
+              Business Name <span className="text-red-500">*</span>
+            </Label>
+            <Input id="user-business" name="businessName" placeholder="Enter business name" required />
+          </div>
+          <div className="space-y-2">
             <Label htmlFor="user-membership">
               Membership Taken <span className="text-red-500">*</span>
             </Label>

--- a/components/user/onboarding-form.js
+++ b/components/user/onboarding-form.js
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/ui/submit-button";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import {
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+} from "@/components/ui/select";
+
+export default function OnboardingForm({ user, action }) {
+  const [step, setStep] = useState(1);
+  const [challenges, setChallenges] = useState([""]);
+
+  function addChallenge() {
+    if (challenges.length < 3) {
+      setChallenges([...challenges, ""]);
+    }
+  }
+
+  function updateChallenge(index, value) {
+    const updated = [...challenges];
+    updated[index] = value;
+    setChallenges(updated);
+  }
+
+  return (
+    <form action={action} className="space-y-6" encType="multipart/form-data">
+      <Card hidden={step !== 1}>
+        <CardHeader>
+          <CardTitle>Step 1</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label>Name</Label>
+            <Input defaultValue={user.name} disabled />
+          </div>
+            <div className="space-y-2">
+              <Label>Email</Label>
+              <Input defaultValue={user.email} disabled />
+            </div>
+            <div className="space-y-2">
+              <Label>Phone Number</Label>
+              <Input defaultValue={user.phone || ""} disabled />
+            </div>
+            <div className="space-y-2">
+              <Label>Membership Taken</Label>
+              <Input defaultValue={user.membership} disabled />
+            </div>
+            <div className="space-y-2">
+              <Label>Start Date</Label>
+              <Input defaultValue={user.startDate} disabled />
+            </div>
+            <div className="space-y-2">
+              <Label>End Date</Label>
+              <Input defaultValue={user.endDate} disabled />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="businessName">Business Name</Label>
+              <Input
+                id="businessName"
+                defaultValue={user.businessName || ""}
+                disabled
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="image">Profile Image</Label>
+              <Input id="image" name="image" type="file" accept="image/*" />
+            </div>
+          <div className="flex justify-end">
+            <Button type="button" onClick={() => setStep(2)}>
+              Next
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+      <Card hidden={step !== 2}>
+        <CardHeader>
+          <CardTitle>Step 2</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="companyAddress">Company Address</Label>
+            <Input
+              id="companyAddress"
+              name="companyAddress"
+              placeholder="Enter company address"
+            />
+          </div>
+            <div className="space-y-2">
+              <Label htmlFor="annualRevenue">Annual Revenue</Label>
+              <Input
+                id="annualRevenue"
+                name="annualRevenue"
+                type="number"
+                placeholder="Enter annual revenue"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="employeeCount">Employee Headcount</Label>
+              <Input
+                id="employeeCount"
+                name="employeeCount"
+                type="number"
+                placeholder="Enter total employees"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="manufacturing">
+                Are you involved in manufacturing?
+              </Label>
+              <Select name="manufacturing">
+                <SelectTrigger id="manufacturing">
+                  <SelectValue placeholder="Select option" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="yes">Yes</SelectItem>
+                  <SelectItem value="no">No</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Top Business Challenges</Label>
+              {challenges.map((c, i) => (
+                <Input
+                  key={i}
+                  name="challenges"
+                  value={c}
+                  onChange={(e) => updateChallenge(i, e.target.value)}
+                  className={i < challenges.length - 1 ? "mb-2" : undefined}
+                />
+              ))}
+              {challenges.length < 3 && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={addChallenge}
+                >
+                  +
+                </Button>
+              )}
+            </div>
+          <div className="flex justify-end">
+            <Button type="button" onClick={() => setStep(3)}>
+              Next
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+      {step === 3 && (
+        <div className="flex justify-center pt-4">
+          <SubmitButton className="px-8 py-6 text-lg" pendingText="Saving...">
+            Get Started
+          </SubmitButton>
+        </div>
+      )}
+    </form>
+  );
+}

--- a/components/user/user-shell.js
+++ b/components/user/user-shell.js
@@ -13,15 +13,24 @@ import {
   DialogTitle,
   DialogClose,
 } from "@/components/ui/dialog";
-import { Eye, Download, Menu, X } from "lucide-react";
+import { Eye, Download, Menu, X, MoreVertical } from "lucide-react";
 
 export default function UserShell({ user, modules, tutorials, logout }) {
   const [view, setView] = useState("modules");
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [profileOpen, setProfileOpen] = useState(false);
+  const profileAvailable =
+    !!user.businessName &&
+    !!user.companyAddress &&
+    user.annualRevenue !== null &&
+    user.employeeCount !== null &&
+    user.manufacturing !== null &&
+    user.businessChallenges.length > 0;
   return (
     <div className="p-4 space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-heading font-bold">Welcome {user.name}!</h1>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 relative">
           <Sheet>
             <SheetTrigger asChild>
               <Button variant="ghost" className="sm:hidden" size="icon">
@@ -44,45 +53,31 @@ export default function UserShell({ user, modules, tutorials, logout }) {
               </nav>
             </SheetContent>
           </Sheet>
-          <Dialog>
-            <DialogTrigger asChild>
-              <button className="h-10 w-10 rounded-full overflow-hidden border">
-                {user.imageUrl ? (
-                  <img src={user.imageUrl} alt={user.name} className="h-full w-full object-cover" />
-                ) : (
-                  <div className="h-full w-full flex items-center justify-center bg-muted text-sm">
-                    {user.name.charAt(0).toUpperCase()}
-                  </div>
-                )}
-              </button>
-            </DialogTrigger>
-            <DialogContent className="rounded-lg">
-              <DialogHeader className="flex flex-row items-center justify-between">
-                <DialogTitle>Profile</DialogTitle>
-                <DialogClose className="cursor-pointer rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none">
-                  <X className="h-4 w-4" />
-                  <span className="sr-only">Close</span>
-                </DialogClose>
-              </DialogHeader>
-              <div className="space-y-2 text-sm">
-                <p><span className="font-medium">Name:</span> {user.name}</p>
-                <p><span className="font-medium">Email:</span> {user.email}</p>
-                <p><span className="font-medium">Phone:</span> {user.phone}</p>
-                <p><span className="font-medium">Membership:</span> {user.membership}</p>
-                <p><span className="font-medium">Start Date:</span> {user.startDate}</p>
-                <p><span className="font-medium">End Date:</span> {user.endDate}</p>
-                {user.businessName && (
-                  <p><span className="font-medium">Business Name:</span> {user.businessName}</p>
-                )}
-                {user.companyAddress && (
-                  <p><span className="font-medium">Company Address:</span> {user.companyAddress}</p>
-                )}
-                {user.employeeCount !== null && (
-                  <p><span className="font-medium">Total Employees:</span> {user.employeeCount}</p>
-                )}
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => setMenuOpen(!menuOpen)}
+              className="p-2 rounded hover:bg-muted"
+            >
+              <MoreVertical className="h-5 w-5" />
+              <span className="sr-only">Open menu</span>
+            </button>
+            {menuOpen && (
+              <div className="absolute right-0 mt-2 w-40 rounded-md border bg-popover text-popover-foreground shadow-md">
+                <button
+                  type="button"
+                  className="block w-full px-4 py-2 text-left text-sm hover:bg-muted disabled:opacity-50"
+                  onClick={() => {
+                    setProfileOpen(true);
+                    setMenuOpen(false);
+                  }}
+                  disabled={!profileAvailable}
+                >
+                  View Profile
+                </button>
               </div>
-            </DialogContent>
-          </Dialog>
+            )}
+          </div>
           <form action={logout}>
             <Button type="submit" variant="destructive">
               Logout
@@ -149,6 +144,59 @@ export default function UserShell({ user, modules, tutorials, logout }) {
           </div>
         )}
       </div>
+      <Dialog open={profileOpen} onOpenChange={setProfileOpen}>
+        <DialogContent className="rounded-lg">
+          <DialogHeader className="flex flex-row items-center justify-between">
+            <DialogTitle>Profile</DialogTitle>
+            <DialogClose className="cursor-pointer rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none">
+              <X className="h-4 w-4" />
+              <span className="sr-only">Close</span>
+            </DialogClose>
+          </DialogHeader>
+          <div className="space-y-4 text-sm">
+            <div className="space-y-1 border rounded p-4">
+              <h3 className="font-medium mb-2">User Info</h3>
+              <p><span className="font-medium">Name:</span> {user.name}</p>
+              <p><span className="font-medium">Email:</span> {user.email}</p>
+              <p><span className="font-medium">Phone:</span> {user.phone}</p>
+              <p><span className="font-medium">Membership:</span> {user.membership}</p>
+              <p><span className="font-medium">Start Date:</span> {user.startDate}</p>
+              <p><span className="font-medium">End Date:</span> {user.endDate}</p>
+            </div>
+            <div className="space-y-1 border rounded p-4">
+              <h3 className="font-medium mb-2">Business Info</h3>
+              {user.businessName && (
+                <p><span className="font-medium">Business Name:</span> {user.businessName}</p>
+              )}
+              {user.companyAddress && (
+                <p><span className="font-medium">Company Address:</span> {user.companyAddress}</p>
+              )}
+              {user.annualRevenue !== null && (
+                <p><span className="font-medium">Annual Revenue:</span> {user.annualRevenue}</p>
+              )}
+              {user.employeeCount !== null && (
+                <p><span className="font-medium">Employee Headcount:</span> {user.employeeCount}</p>
+              )}
+              {user.manufacturing !== null && (
+                <p>
+                  <span className="font-medium">Manufacturing:</span> {" "}
+                  {user.manufacturing ? "Yes" : "No"}
+                </p>
+              )}
+              {user.businessChallenges.length > 0 && (
+                <div>
+                  <span className="font-medium">Business Challenges:</span>
+                  <ul className="list-disc ml-5">
+                    {user.businessChallenges.map((c, i) => (
+                      <li key={i}>{c}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/lib/users.js
+++ b/lib/users.js
@@ -12,6 +12,7 @@ export async function addUser(formData) {
   const name = formData.get("name");
   const email = formData.get("email");
   const phone = formData.get("phone");
+  const businessName = formData.get("businessName");
   const membership = formData.get("membership");
   const startDate = new Date(formData.get("startDate"));
   const endDate = new Date(formData.get("endDate"));
@@ -22,6 +23,7 @@ export async function addUser(formData) {
       name,
       email,
       phone,
+      businessName,
       membership,
       startDate,
       endDate,
@@ -58,11 +60,20 @@ export async function setUserActive(id, active) {
 }
 
 export async function completeOnboarding(id, formData) {
-  const businessName = formData.get("businessName") || null;
   const companyAddress = formData.get("companyAddress") || null;
+  const annualRevenue = formData.get("annualRevenue")
+    ? Number(formData.get("annualRevenue"))
+    : null;
   const employeeCount = formData.get("employeeCount")
     ? Number(formData.get("employeeCount"))
     : null;
+  const manufacturing = formData.get("manufacturing")
+    ? formData.get("manufacturing") === "yes"
+    : null;
+  const businessChallenges = formData
+    .getAll("challenges")
+    .map((c) => c.trim())
+    .filter(Boolean);
   const image = formData.get("image");
   let imageUrl = null;
   if (image && typeof image === "object") {
@@ -72,7 +83,14 @@ export async function completeOnboarding(id, formData) {
   }
   await prisma.user.update({
     where: { id },
-    data: { businessName, companyAddress, employeeCount, imageUrl },
+    data: {
+      companyAddress,
+      annualRevenue,
+      employeeCount,
+      manufacturing,
+      businessChallenges,
+      imageUrl,
+    },
   });
   revalidatePath("/user");
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,7 +34,10 @@ model User {
   imageUrl      String?
   businessName  String?
   companyAddress String?
+  annualRevenue Int?
   employeeCount Int?
+  manufacturing Boolean?
+  businessChallenges String[] @default([])
   status        String      @default("CREATED")
   lastLogin     DateTime?
   createdAt     DateTime    @default(now())


### PR DESCRIPTION
## Summary
- allow admins to set business name when creating users
- add multi-step onboarding with company details, revenue, and challenges
- enhance dashboard with profile dropdown and structured profile view

## Testing
- `npx prisma generate`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfd7e5a84483239d7e3bdbe74e30e7