### PR TITLE
Add dedicated profile pages for users and admins

### DIFF
--- a/app/admin/users/[id]/page.js
+++ b/app/admin/users/[id]/page.js
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import { prisma } from "@/lib/prisma";
+import UserProfile from "@/components/user-profile";
+
+export default async function AdminUserProfilePage({ params }) {
+  const id = Number(params.id);
+  const user = await prisma.user.findUnique({ where: { id } });
+  if (!user) {
+    return <div className="p-4">User not found</div>;
+  }
+  const formattedUser = {
+    ...user,
+    startDate: user.startDate.toISOString().split("T")[0],
+    endDate: user.endDate.toISOString().split("T")[0],
+  };
+  return (
+    <div className="p-4 space-y-6">
+      <Link href="/admin" className="text-sm text-muted-foreground hover:underline">
+        &larr; Back
+      </Link>
+      <UserProfile user={formattedUser} />
+    </div>
+  );
+}

--- a/app/user/profile/page.js
+++ b/app/user/profile/page.js
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import UserProfile from "@/components/user-profile";
+
+export default async function UserProfilePage() {
+  const userIdCookie = cookies().get("userId");
+  if (!userIdCookie) redirect("/");
+  const id = Number(userIdCookie.value);
+  const user = await prisma.user.findUnique({ where: { id } });
+  if (!user) redirect("/");
+  const formattedUser = {
+    ...user,
+    startDate: user.startDate.toISOString().split("T")[0],
+    endDate: user.endDate.toISOString().split("T")[0],
+  };
+  return (
+    <div className="p-4 space-y-6">
+      <Link href="/user" className="text-sm text-muted-foreground hover:underline">
+        &larr; Back
+      </Link>
+      <UserProfile user={formattedUser} />
+    </div>
+  );
+}

--- a/components/admin/user-card.js
+++ b/components/admin/user-card.js
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useActionState } from "react";
+import Link from "next/link";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { SubmitButton } from "@/components/ui/submit-button";
@@ -17,7 +18,7 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
-import { Key, Trash, X } from "lucide-react";
+import { Key, Trash, X, MoreVertical } from "lucide-react";
 import { setUserActive, deleteUser, updateCredentials } from "@/lib/users";
 
 export default function UserCard({ user }) {
@@ -37,6 +38,7 @@ export default function UserCard({ user }) {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [editing, setEditing] = useState(false);
   const [credOpen, setCredOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
   const initialCredState = { success: false };
   async function handleUpdate(prevState, formData) {
     await updateCredentials(id, formData);
@@ -68,111 +70,134 @@ export default function UserCard({ user }) {
 
   return (
     <Card className="p-4">
-      <div className="flex flex-col gap-4">
+      <div className="flex items-start justify-between">
         <div className="flex flex-col">
           <h3 className="font-medium">{name}</h3>
           <p className="text-sm text-muted-foreground">{email}</p>
         </div>
-        <div className="flex flex-wrap items-center gap-4">
-          <p className="text-sm text-muted-foreground">{membership}</p>
-          <p className="text-sm text-muted-foreground">
-            Ends {endDate.toISOString().split("T")[0]}
-          </p>
-          <Badge variant={status.toLowerCase()}>{status}</Badge>
-          <div className="flex items-center gap-2">
-            <Switch
-              id={`user-${id}`}
-              checked={isActive}
-              onCheckedChange={() => setConfirmOpen(true)}
-            />
-            <Label htmlFor={`user-${id}`}>
-              {status === "ACTIVE" ? "Active" : status === "EXPIRED" ? "Expired" : "Inactive"}
-            </Label>
-          </div>
-          <Dialog
-            open={credOpen}
-            onOpenChange={(o) => {
-              setCredOpen(o);
-              if (!o) setEditing(false);
-            }}
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setMenuOpen(!menuOpen)}
+            className="p-2 rounded hover:bg-muted"
           >
-            <DialogTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Key className="h-4 w-4" />
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="rounded-lg sm:max-w-sm">
-              <DialogHeader className="flex flex-row items-center justify-between">
-                <DialogTitle>Credentials</DialogTitle>
-                <DialogClose className="rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none">
-                  <X className="h-4 w-4" />
-                  <span className="sr-only">Close</span>
-                </DialogClose>
-              </DialogHeader>
-              {editing ? (
-                <form action={credAction} className="space-y-4">
-                  <div className="space-y-2">
-                    <Label htmlFor={`email-${id}`}>Email</Label>
-                    <Input
-                      id={`email-${id}`}
-                      name="email"
-                      type="email"
-                      defaultValue={email}
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor={`password-${id}`}>Password</Label>
-                    <Input
-                      id={`password-${id}`}
-                      name="password"
-                      defaultValue={passwordPlain}
-                    />
-                  </div>
-                  <div className="flex justify-end gap-2">
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      onClick={() => setEditing(false)}
-                    >
-                      Cancel
-                    </Button>
-                    <SubmitButton type="submit" pendingText="Saving...">
-                      Save
-                    </SubmitButton>
-                  </div>
-                </form>
-              ) : (
-                <div className="space-y-4">
-                  <div>
-                    <p className="text-sm font-medium">Email</p>
-                    <p className="text-sm text-muted-foreground">{email}</p>
-                  </div>
-                  <div>
-                    <p className="text-sm font-medium">Password</p>
-                    <p className="text-sm text-muted-foreground">{passwordPlain}</p>
-                  </div>
-                  <div className="flex justify-end">
-                    <Button onClick={() => setEditing(true)}>
-                      Update Credentials
-                    </Button>
-                  </div>
-                </div>
-              )}
-            </DialogContent>
-          </Dialog>
-          <form action={deleteUser.bind(null, id)}>
-            <SubmitButton
-              type="submit"
-              variant="ghost"
-              size="icon"
-              className="text-destructive"
-              pendingText="Deleting..."
-            >
-              <Trash className="h-4 w-4" />
-              <span className="sr-only">Delete</span>
-            </SubmitButton>
-          </form>
+            <MoreVertical className="h-4 w-4" />
+            <span className="sr-only">Open menu</span>
+          </button>
+          {menuOpen && (
+            <div className="absolute right-0 mt-2 w-32 rounded-md border bg-popover text-popover-foreground shadow-md">
+              <Link
+                href={`/admin/users/${id}`}
+                className="block px-4 py-2 text-sm hover:bg-muted"
+                onClick={() => setMenuOpen(false)}
+              >
+                View Profile
+              </Link>
+            </div>
+          )}
         </div>
+      </div>
+      <div className="mt-4 flex flex-wrap items-center gap-4">
+        {membership && (
+          <p className="text-sm text-muted-foreground">{membership}</p>
+        )}
+        <p className="text-sm text-muted-foreground">
+          Ends {endDate.toISOString().split("T")[0]}
+        </p>
+        <Badge variant={status.toLowerCase()}>{status}</Badge>
+        <div className="flex items-center gap-2">
+          <Switch
+            id={`user-${id}`}
+            checked={isActive}
+            onCheckedChange={() => setConfirmOpen(true)}
+          />
+          <Label htmlFor={`user-${id}`}>
+            {status === "ACTIVE" ? "Active" : status === "EXPIRED" ? "Expired" : "Inactive"}
+          </Label>
+        </div>
+        <Dialog
+          open={credOpen}
+          onOpenChange={(o) => {
+            setCredOpen(o);
+            if (!o) setEditing(false);
+          }}
+        >
+          <DialogTrigger asChild>
+            <Button variant="ghost" size="icon">
+              <Key className="h-4 w-4" />
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="rounded-lg sm:max-w-sm">
+            <DialogHeader className="flex flex-row items-center justify-between">
+              <DialogTitle>Credentials</DialogTitle>
+              <DialogClose className="rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none">
+                <X className="h-4 w-4" />
+                <span className="sr-only">Close</span>
+              </DialogClose>
+            </DialogHeader>
+            {editing ? (
+              <form action={credAction} className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor={`email-${id}`}>Email</Label>
+                  <Input
+                    id={`email-${id}`}
+                    name="email"
+                    type="email"
+                    defaultValue={email}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor={`password-${id}`}>Password</Label>
+                  <Input
+                    id={`password-${id}`}
+                    name="password"
+                    defaultValue={passwordPlain}
+                  />
+                </div>
+                <div className="flex justify-end gap-2">
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={() => setEditing(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <SubmitButton type="submit" pendingText="Saving...">
+                    Save
+                  </SubmitButton>
+                </div>
+              </form>
+            ) : (
+              <div className="space-y-4">
+                <div>
+                  <p className="text-sm font-medium">Email</p>
+                  <p className="text-sm text-muted-foreground">{email}</p>
+                </div>
+                <div>
+                  <p className="text-sm font-medium">Password</p>
+                  <p className="text-sm text-muted-foreground">{passwordPlain}</p>
+                </div>
+                <div className="flex justify-end">
+                  <Button onClick={() => setEditing(true)}>
+                    Update Credentials
+                  </Button>
+                </div>
+              </div>
+            )}
+          </DialogContent>
+        </Dialog>
+        <form action={deleteUser.bind(null, id)}>
+          <SubmitButton
+            type="submit"
+            variant="ghost"
+            size="icon"
+            className="text-destructive"
+            pendingText="Deleting..."
+          >
+            <Trash className="h-4 w-4" />
+            <span className="sr-only">Delete</span>
+          </SubmitButton>
+        </form>
       </div>
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <DialogContent

--- a/components/user-profile.js
+++ b/components/user-profile.js
@@ -1,0 +1,102 @@
+import React from "react";
+
+export default function UserProfile({ user }) {
+  const {
+    name,
+    email,
+    phone,
+    membership,
+    startDate,
+    endDate,
+    businessName,
+    companyAddress,
+    annualRevenue,
+    employeeCount,
+    manufacturing,
+    businessChallenges,
+  } = user;
+  return (
+    <div className="max-w-3xl mx-auto space-y-8">
+      <div className="grid gap-6 md:grid-cols-2">
+        <section className="space-y-4 border rounded p-4">
+          <h2 className="text-lg font-medium">User Info</h2>
+          <dl className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <dt className="font-medium">Name</dt>
+              <dd>{name}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="font-medium">Email</dt>
+              <dd>{email}</dd>
+            </div>
+            {phone && (
+              <div className="flex justify-between">
+                <dt className="font-medium">Phone</dt>
+                <dd>{phone}</dd>
+              </div>
+            )}
+            <div className="flex justify-between">
+              <dt className="font-medium">Membership</dt>
+              <dd>{membership}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="font-medium">Start Date</dt>
+              <dd>{startDate}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="font-medium">End Date</dt>
+              <dd>{endDate}</dd>
+            </div>
+          </dl>
+        </section>
+        <section className="space-y-4 border rounded p-4">
+          <h2 className="text-lg font-medium">Business Info</h2>
+          <dl className="space-y-2 text-sm">
+            {businessName && (
+              <div className="flex justify-between">
+                <dt className="font-medium">Business Name</dt>
+                <dd className="text-right">{businessName}</dd>
+              </div>
+            )}
+            {companyAddress && (
+              <div className="flex justify-between">
+                <dt className="font-medium">Company Address</dt>
+                <dd className="text-right">{companyAddress}</dd>
+              </div>
+            )}
+            {annualRevenue !== null && (
+              <div className="flex justify-between">
+                <dt className="font-medium">Annual Revenue</dt>
+                <dd>{annualRevenue}</dd>
+              </div>
+            )}
+            {employeeCount !== null && (
+              <div className="flex justify-between">
+                <dt className="font-medium">Employee Headcount</dt>
+                <dd>{employeeCount}</dd>
+              </div>
+            )}
+            {manufacturing !== null && (
+              <div className="flex justify-between">
+                <dt className="font-medium">Manufacturing</dt>
+                <dd>{manufacturing ? "Yes" : "No"}</dd>
+              </div>
+            )}
+            {businessChallenges.length > 0 && (
+              <div className="space-y-1">
+                <dt className="font-medium">Business Challenges</dt>
+                <dd>
+                  <ul className="list-disc ml-4 space-y-1">
+                    {businessChallenges.map((c, i) => (
+                      <li key={i}>{c}</li>
+                    ))}
+                  </ul>
+                </dd>
+              </div>
+            )}
+          </dl>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/components/user/user-shell.js
+++ b/components/user/user-shell.js
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Sheet, SheetTrigger, SheetContent, SheetClose } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
@@ -18,7 +19,6 @@ import { Eye, Download, Menu, X, MoreVertical } from "lucide-react";
 export default function UserShell({ user, modules, tutorials, logout }) {
   const [view, setView] = useState("modules");
   const [menuOpen, setMenuOpen] = useState(false);
-  const [profileOpen, setProfileOpen] = useState(false);
   const profileAvailable =
     !!user.businessName &&
     !!user.companyAddress &&
@@ -64,17 +64,19 @@ export default function UserShell({ user, modules, tutorials, logout }) {
             </button>
             {menuOpen && (
               <div className="absolute right-0 mt-2 w-40 rounded-md border bg-popover text-popover-foreground shadow-md">
-                <button
-                  type="button"
-                  className="block w-full px-4 py-2 text-left text-sm hover:bg-muted disabled:opacity-50"
-                  onClick={() => {
-                    setProfileOpen(true);
-                    setMenuOpen(false);
-                  }}
-                  disabled={!profileAvailable}
-                >
-                  View Profile
-                </button>
+                {profileAvailable ? (
+                  <Link
+                    href="/user/profile"
+                    className="block w-full px-4 py-2 text-left text-sm hover:bg-muted"
+                    onClick={() => setMenuOpen(false)}
+                  >
+                    View Profile
+                  </Link>
+                ) : (
+                  <span className="block w-full px-4 py-2 text-left text-sm opacity-50">
+                    View Profile
+                  </span>
+                )}
               </div>
             )}
           </div>
@@ -144,59 +146,6 @@ export default function UserShell({ user, modules, tutorials, logout }) {
           </div>
         )}
       </div>
-      <Dialog open={profileOpen} onOpenChange={setProfileOpen}>
-        <DialogContent className="rounded-lg">
-          <DialogHeader className="flex flex-row items-center justify-between">
-            <DialogTitle>Profile</DialogTitle>
-            <DialogClose className="cursor-pointer rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none">
-              <X className="h-4 w-4" />
-              <span className="sr-only">Close</span>
-            </DialogClose>
-          </DialogHeader>
-          <div className="space-y-4 text-sm">
-            <div className="space-y-1 border rounded p-4">
-              <h3 className="font-medium mb-2">User Info</h3>
-              <p><span className="font-medium">Name:</span> {user.name}</p>
-              <p><span className="font-medium">Email:</span> {user.email}</p>
-              <p><span className="font-medium">Phone:</span> {user.phone}</p>
-              <p><span className="font-medium">Membership:</span> {user.membership}</p>
-              <p><span className="font-medium">Start Date:</span> {user.startDate}</p>
-              <p><span className="font-medium">End Date:</span> {user.endDate}</p>
-            </div>
-            <div className="space-y-1 border rounded p-4">
-              <h3 className="font-medium mb-2">Business Info</h3>
-              {user.businessName && (
-                <p><span className="font-medium">Business Name:</span> {user.businessName}</p>
-              )}
-              {user.companyAddress && (
-                <p><span className="font-medium">Company Address:</span> {user.companyAddress}</p>
-              )}
-              {user.annualRevenue !== null && (
-                <p><span className="font-medium">Annual Revenue:</span> {user.annualRevenue}</p>
-              )}
-              {user.employeeCount !== null && (
-                <p><span className="font-medium">Employee Headcount:</span> {user.employeeCount}</p>
-              )}
-              {user.manufacturing !== null && (
-                <p>
-                  <span className="font-medium">Manufacturing:</span> {" "}
-                  {user.manufacturing ? "Yes" : "No"}
-                </p>
-              )}
-              {user.businessChallenges.length > 0 && (
-                <div>
-                  <span className="font-medium">Business Challenges:</span>
-                  <ul className="list-disc ml-5">
-                    {user.businessChallenges.map((c, i) => (
-                      <li key={i}>{c}</li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-            </div>
-          </div>
-        </DialogContent>
-      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add shared `UserProfile` component to display user and business information
- Create admin and user profile pages using the new component
- Replace profile dialog with page navigation and add menu option in admin user cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfdcf601ac83239de934de9aa3a534