### PR TITLE
Enhance onboarding and profile flows

### DIFF
--- a/components/admin/user-card.js
+++ b/components/admin/user-card.js
@@ -31,10 +31,23 @@ export default function UserCard({ user }) {
     endDate,
     status: rawStatus,
     passwordPlain,
+    businessName,
+    companyAddress,
+    annualRevenue,
+    employeeCount,
+    manufacturing,
+    businessChallenges,
   } = user;
   const today = new Date();
   const status = endDate < today ? "EXPIRED" : rawStatus;
   const isActive = status === "ACTIVE";
+  const profileAvailable =
+    !!businessName &&
+    !!companyAddress &&
+    annualRevenue !== null &&
+    employeeCount !== null &&
+    manufacturing !== null &&
+    businessChallenges.length > 0;
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [editing, setEditing] = useState(false);
   const [credOpen, setCredOpen] = useState(false);
@@ -86,13 +99,19 @@ export default function UserCard({ user }) {
           </button>
           {menuOpen && (
             <div className="absolute right-0 mt-2 w-32 rounded-md border bg-popover text-popover-foreground shadow-md">
-              <Link
-                href={`/admin/users/${id}`}
-                className="block px-4 py-2 text-sm hover:bg-muted"
-                onClick={() => setMenuOpen(false)}
-              >
-                View Profile
-              </Link>
+              {profileAvailable ? (
+                <Link
+                  href={`/admin/users/${id}`}
+                  className="block px-4 py-2 text-sm hover:bg-muted"
+                  onClick={() => setMenuOpen(false)}
+                >
+                  View Profile
+                </Link>
+              ) : (
+                <span className="block px-4 py-2 text-sm opacity-50">
+                  View Profile
+                </span>
+              )}
             </div>
           )}
         </div>

--- a/components/user-profile.js
+++ b/components/user-profile.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 export default function UserProfile({ user }) {
   const {
@@ -16,10 +17,12 @@ export default function UserProfile({ user }) {
     businessChallenges,
   } = user;
   return (
-    <div className="max-w-3xl mx-auto space-y-8">
-      <div className="grid gap-6 md:grid-cols-2">
-        <section className="space-y-4 border rounded p-4">
-          <h2 className="text-lg font-medium">User Info</h2>
+    <div className="max-w-3xl mx-auto space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>User Info</CardTitle>
+        </CardHeader>
+        <CardContent>
           <dl className="space-y-2 text-sm">
             <div className="flex justify-between">
               <dt className="font-medium">Name</dt>
@@ -48,9 +51,13 @@ export default function UserProfile({ user }) {
               <dd>{endDate}</dd>
             </div>
           </dl>
-        </section>
-        <section className="space-y-4 border rounded p-4">
-          <h2 className="text-lg font-medium">Business Info</h2>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Business Info</CardTitle>
+        </CardHeader>
+        <CardContent>
           <dl className="space-y-2 text-sm">
             {businessName && (
               <div className="flex justify-between">
@@ -95,8 +102,8 @@ export default function UserProfile({ user }) {
               </div>
             )}
           </dl>
-        </section>
-      </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/components/user/onboarding-form.js
+++ b/components/user/onboarding-form.js
@@ -18,6 +18,7 @@ export default function OnboardingForm({ user, action }) {
   const [step, setStep] = useState(1);
   const [challenges, setChallenges] = useState([""]);
   const [imageError, setImageError] = useState("");
+  const [useExistingPassword, setUseExistingPassword] = useState(true);
 
   const MAX_IMAGE_SIZE = 4 * 1024 * 1024; // 4MB
 
@@ -175,7 +176,47 @@ export default function OnboardingForm({ user, action }) {
           </div>
         </CardContent>
       </Card>
-      {step === 3 && (
+      <Card hidden={step !== 3}>
+        <CardHeader>
+          <CardTitle>Step 3</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <label className="flex items-center space-x-2 text-sm">
+              <input
+                type="radio"
+                checked={useExistingPassword}
+                onChange={() => setUseExistingPassword(true)}
+              />
+              <span>Continue with current password</span>
+            </label>
+          </div>
+          <div className="space-y-2">
+            <label className="flex items-center space-x-2 text-sm">
+              <input
+                type="radio"
+                checked={!useExistingPassword}
+                onChange={() => setUseExistingPassword(false)}
+              />
+              <span>Set new password</span>
+            </label>
+            {!useExistingPassword && (
+              <Input
+                id="password"
+                name="password"
+                type="text"
+                placeholder="Enter new password"
+              />
+            )}
+          </div>
+          <div className="flex justify-end">
+            <Button type="button" onClick={() => setStep(4)}>
+              Next
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+      {step === 4 && (
         <div className="flex justify-center pt-4">
           <SubmitButton className="px-8 py-6 text-lg" pendingText="Saving...">
             Get Started

--- a/components/user/user-shell.js
+++ b/components/user/user-shell.js
@@ -14,7 +14,8 @@ import {
   DialogTitle,
   DialogClose,
 } from "@/components/ui/dialog";
-import { Eye, Download, Menu, X, MoreVertical } from "lucide-react";
+import { Eye, Download, Menu, X } from "lucide-react";
+import Image from "next/image";
 
 export default function UserShell({ user, modules, tutorials, logout }) {
   const [view, setView] = useState("modules");
@@ -57,9 +58,21 @@ export default function UserShell({ user, modules, tutorials, logout }) {
             <button
               type="button"
               onClick={() => setMenuOpen(!menuOpen)}
-              className="p-2 rounded hover:bg-muted"
+              className="rounded-full focus:outline-none"
             >
-              <MoreVertical className="h-5 w-5" />
+              {user.imageUrl ? (
+                <Image
+                  src={user.imageUrl}
+                  alt="Profile"
+                  width={40}
+                  height={40}
+                  className="h-10 w-10 rounded-full object-cover"
+                />
+              ) : (
+                <div className="h-10 w-10 rounded-full bg-muted flex items-center justify-center text-sm font-medium">
+                  {user.name.charAt(0)}
+                </div>
+              )}
               <span className="sr-only">Open menu</span>
             </button>
             {menuOpen && (

--- a/lib/users.js
+++ b/lib/users.js
@@ -81,16 +81,23 @@ export async function completeOnboarding(id, formData) {
     const buffer = Buffer.from(bytes);
     imageUrl = `data:${image.type};base64,${buffer.toString("base64")}`;
   }
+  const password = formData.get("password");
+  const data = {
+    companyAddress,
+    annualRevenue,
+    employeeCount,
+    manufacturing,
+    businessChallenges,
+    imageUrl,
+  };
+  if (password) {
+    const hashed = await bcrypt.hash(password, 10);
+    data.password = hashed;
+    data.passwordPlain = password;
+  }
   await prisma.user.update({
     where: { id },
-    data: {
-      companyAddress,
-      annualRevenue,
-      employeeCount,
-      manufacturing,
-      businessChallenges,
-      imageUrl,
-    },
+    data,
   });
   revalidatePath("/user");
 }


### PR DESCRIPTION
## Summary
- replace user menu dots with profile image dropdown
- disable admin view profile until onboarding completion
- redesign user profile layout using cards and add password step to onboarding

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bff63e38e88323921392f3cf4d632e