### PR TITLE
Add checklist management and user deletion confirmation

### DIFF
--- a/app/admin/users/[id]/page.js
+++ b/app/admin/users/[id]/page.js
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { prisma } from "@/lib/prisma";
+import { ensureFirstLevelChecklist, getChecklist } from "@/lib/checklists";
 import UserProfile from "@/components/user-profile";
 
 export default async function AdminUserProfilePage({ params }) {
@@ -8,6 +9,8 @@ export default async function AdminUserProfilePage({ params }) {
   if (!user) {
     return <div className="p-4">User not found</div>;
   }
+  await ensureFirstLevelChecklist(user);
+  const checklist = await getChecklist(id);
   const formattedUser = {
     ...user,
     startDate: user.startDate.toISOString().split("T")[0],
@@ -18,7 +21,7 @@ export default async function AdminUserProfilePage({ params }) {
       <Link href="/admin" className="text-sm text-muted-foreground hover:underline">
         &larr; Back
       </Link>
-      <UserProfile user={formattedUser} />
+      <UserProfile user={formattedUser} checklist={checklist} isAdmin />
     </div>
   );
 }

--- a/app/user/profile/page.js
+++ b/app/user/profile/page.js
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
+import { ensureFirstLevelChecklist, getChecklist } from "@/lib/checklists";
 import UserProfile from "@/components/user-profile";
 
 export default async function UserProfilePage() {
@@ -10,6 +11,8 @@ export default async function UserProfilePage() {
   const id = Number(userIdCookie.value);
   const user = await prisma.user.findUnique({ where: { id } });
   if (!user) redirect("/");
+  await ensureFirstLevelChecklist(user);
+  const checklist = await getChecklist(id);
   const formattedUser = {
     ...user,
     startDate: user.startDate.toISOString().split("T")[0],
@@ -20,7 +23,7 @@ export default async function UserProfilePage() {
       <Link href="/user" className="text-sm text-muted-foreground hover:underline">
         &larr; Back
       </Link>
-      <UserProfile user={formattedUser} />
+      <UserProfile user={formattedUser} checklist={checklist} />
     </div>
   );
 }

--- a/components/admin/user-card.js
+++ b/components/admin/user-card.js
@@ -49,6 +49,7 @@ export default function UserCard({ user }) {
     manufacturing !== null &&
     businessChallenges.length > 0;
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
   const [editing, setEditing] = useState(false);
   const [credOpen, setCredOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -205,18 +206,16 @@ export default function UserCard({ user }) {
             )}
           </DialogContent>
         </Dialog>
-        <form action={deleteUser.bind(null, id)}>
-          <SubmitButton
-            type="submit"
-            variant="ghost"
-            size="icon"
-            className="text-destructive"
-            pendingText="Deleting..."
-          >
-            <Trash className="h-4 w-4" />
-            <span className="sr-only">Delete</span>
-          </SubmitButton>
-        </form>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="text-destructive"
+          onClick={() => setDeleteOpen(true)}
+        >
+          <Trash className="h-4 w-4" />
+          <span className="sr-only">Delete</span>
+        </Button>
       </div>
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <DialogContent
@@ -235,6 +234,35 @@ export default function UserCard({ user }) {
               </Button>
             </DialogClose>
             <Button onClick={handleToggle}>Confirm</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent
+          className="rounded-lg"
+          onInteractOutside={(e) => e.preventDefault()}
+        >
+          <DialogHeader>
+            <DialogTitle>Delete user?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            This action cannot be undone. This will permanently delete the user
+            and their records.
+          </p>
+          <div className="flex justify-end gap-2">
+            <DialogClose asChild>
+              <Button type="button" variant="secondary">
+                Cancel
+              </Button>
+            </DialogClose>
+            <form action={deleteUser.bind(null, id)}>
+              <SubmitButton
+                variant="destructive"
+                pendingText="Deleting..."
+              >
+                Delete
+              </SubmitButton>
+            </form>
           </div>
         </DialogContent>
       </Dialog>

--- a/components/ui/badge.js
+++ b/components/ui/badge.js
@@ -6,6 +6,9 @@ const variants = {
   active: "bg-teal text-white",
   inactive: "bg-destructive/10 text-destructive",
   expired: "bg-destructive/10 text-destructive",
+  not_started: "bg-gray-200 text-gray-800",
+  in_progress: "bg-yellow-200 text-yellow-800",
+  done: "bg-green-200 text-green-800",
 };
 
 export function Badge({ variant = "active", className, ...props }) {

--- a/components/user-profile.js
+++ b/components/user-profile.js
@@ -1,7 +1,11 @@
 import React from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { SubmitButton } from "@/components/ui/submit-button";
+import { updateChecklistItem } from "@/lib/checklists";
 
-export default function UserProfile({ user }) {
+export default function UserProfile({ user, checklist = [], isAdmin = false }) {
   const {
     name,
     email,
@@ -16,6 +20,21 @@ export default function UserProfile({ user }) {
     manufacturing,
     businessChallenges,
   } = user;
+
+  const grouped = checklist.reduce((acc, item) => {
+    acc[item.level] = acc[item.level] || [];
+    acc[item.level].push(item);
+    return acc;
+  }, {});
+
+  const statusLabels = {
+    NOT_STARTED: "Not started",
+    IN_PROGRESS: "In Progress",
+    DONE: "Done",
+  };
+
+  const levels = ["First", "Second", "Third"];
+
   return (
     <div className="max-w-3xl mx-auto space-y-6">
       <Card>
@@ -102,6 +121,103 @@ export default function UserProfile({ user }) {
               </div>
             )}
           </dl>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Checklists</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {levels.map((label, idx) => {
+            const level = idx + 1;
+            const items = grouped[level] || [];
+            return (
+              <details key={level} className="mb-4">
+                <summary className="cursor-pointer font-medium">
+                  {label} Level Checklist
+                </summary>
+                <ul className="mt-2 space-y-2">
+                  {items.length > 0 ? (
+                    items.map((item) => (
+                      <li key={item.id} className="border rounded p-2 text-sm">
+                        <p className="font-medium">{item.activity}</p>
+                        {isAdmin ? (
+                          <form
+                            action={updateChecklistItem.bind(null, item.id)}
+                            className="mt-2 space-y-2"
+                          >
+                            <div className="flex flex-col">
+                              <label className="text-xs font-medium">
+                                Deadline
+                              </label>
+                              <input
+                                type="date"
+                                name="deadline"
+                                defaultValue={item.deadline
+                                  .toISOString()
+                                  .split("T")[0]}
+                                className="border rounded px-2 py-1 text-xs"
+                              />
+                            </div>
+                            <div className="flex flex-col">
+                              <label className="text-xs font-medium">
+                                Status
+                              </label>
+                              <select
+                                name="status"
+                                defaultValue={item.status}
+                                className="border rounded px-2 py-1 text-xs"
+                              >
+                                <option value="NOT_STARTED">Not started</option>
+                                <option value="IN_PROGRESS">In Progress</option>
+                                <option value="DONE">Done</option>
+                              </select>
+                            </div>
+                            <div className="flex flex-col">
+                              <label className="text-xs font-medium">
+                                Remarks
+                              </label>
+                              <Input
+                                name="remarks"
+                                defaultValue={item.remarks}
+                                className="h-8 text-xs"
+                              />
+                            </div>
+                            <div className="flex justify-end">
+                              <SubmitButton pendingText="Saving...">
+                                Save
+                              </SubmitButton>
+                            </div>
+                          </form>
+                        ) : (
+                          <div className="mt-2 space-y-1">
+                            <p>Deadline: {item.deadline.toISOString().split("T")[0]}</p>
+                            <Badge variant={item.status.toLowerCase()}>
+                              {statusLabels[item.status]}
+                            </Badge>
+                            <p>Remarks: {item.remarks}</p>
+                          </div>
+                        )}
+                        {item.updatedBy && item.updatedAt && (
+                          <p className="text-xs text-muted-foreground mt-1">
+                            Updated by {item.updatedBy} at{" "}
+                            {item.updatedAt
+                              .toISOString()
+                              .replace("T", " ")
+                              .slice(0, 16)}
+                          </p>
+                        )}
+                      </li>
+                    ))
+                  ) : (
+                    <li className="text-sm text-muted-foreground">
+                      No activities
+                    </li>
+                  )}
+                </ul>
+              </details>
+            );
+          })}
         </CardContent>
       </Card>
     </div>

--- a/lib/checklists.js
+++ b/lib/checklists.js
@@ -1,0 +1,57 @@
+import { prisma } from "@/lib/prisma";
+
+export const FIRST_LEVEL_ACTIVITIES = [
+  "High Level Organization Structure & Functional Org Chart",
+  "HR deployment matrix & gap analysis",
+  "Develop a detailed Master List of Employees",
+  "Vision, Mission and Policies",
+  "Identify a leadership team representing each function or the best team members to lead this change management program",
+  "Master List of all Suppliers/Vendors supplying material or anything for the last 3-5 years(Active/repeated/Approved)",
+  "Master List of Customers of served in last 5 years with complete contact details - Active / Nonactive / Repeated",
+  "Master Daily Attendance System with one month MIS",
+  "Company Profile (1 Page) & 10-15 Slide Presentation. Talk about your major achievements so far.",
+  "Job Description of each employee (Role, Responsibility, Authority & Accountability)",
+  "Remove all unnecessary documents/files/material from each office/cabin/shop floor and organise everything with an approach of identification of each and everything after putting everything at its designated places",
+  "Design and develop company wide communication material (posters, standys, dashboards etc.)",
+  "Master of SKILL MATRIX covering everyone in company",
+  "SIPOC for each Function reflected in organization chart and as per high level process chacklist",
+  "Process Flow Chart for each process under each Function",
+];
+
+export async function ensureFirstLevelChecklist(user) {
+  const count = await prisma.checklistItem.count({
+    where: { userId: user.id, level: 1 },
+  });
+  if (count === 0) {
+    const data = FIRST_LEVEL_ACTIVITIES.map((activity) => ({
+      userId: user.id,
+      level: 1,
+      activity,
+      deadline: user.endDate,
+    }));
+    await prisma.checklistItem.createMany({ data });
+  }
+}
+
+export async function getChecklist(userId) {
+  return prisma.checklistItem.findMany({
+    where: { userId },
+    orderBy: [{ level: "asc" }, { id: "asc" }],
+  });
+}
+
+export async function updateChecklistItem(id, formData) {
+  const status = formData.get("status");
+  const deadline = new Date(formData.get("deadline"));
+  const remarks = formData.get("remarks");
+  await prisma.checklistItem.update({
+    where: { id },
+    data: {
+      status,
+      deadline,
+      remarks,
+      updatedBy: "admin",
+      updatedAt: new Date(),
+    },
+  });
+}

--- a/prisma/migrations/20251105000000_add_checklist_items/migration.sql
+++ b/prisma/migrations/20251105000000_add_checklist_items/migration.sql
@@ -1,0 +1,20 @@
+-- CreateEnum
+CREATE TYPE "public"."ActivityStatus" AS ENUM ('NOT_STARTED', 'IN_PROGRESS', 'DONE');
+
+-- CreateTable
+CREATE TABLE "public"."ChecklistItem" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "level" INTEGER NOT NULL,
+    "activity" TEXT NOT NULL,
+    "deadline" TIMESTAMP(3) NOT NULL,
+    "status" "public"."ActivityStatus" NOT NULL DEFAULT 'NOT_STARTED',
+    "remarks" TEXT NOT NULL DEFAULT 'nil',
+    "updatedBy" TEXT,
+    "updatedAt" TIMESTAMP(3),
+
+    CONSTRAINT "ChecklistItem_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "public"."ChecklistItem" ADD CONSTRAINT "ChecklistItem_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,12 @@ enum Membership {
   PLATINUM
 }
 
+enum ActivityStatus {
+  NOT_STARTED
+  IN_PROGRESS
+  DONE
+}
+
 model User {
   id            Int         @id @default(autoincrement())
   name          String
@@ -62,4 +68,17 @@ model Tutorial {
   active      Boolean  @default(true)
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+}
+
+model ChecklistItem {
+  id        Int            @id @default(autoincrement())
+  user      User           @relation(fields: [userId], references: [id])
+  userId    Int
+  level     Int
+  activity  String
+  deadline  DateTime
+  status    ActivityStatus @default(NOT_STARTED)
+  remarks   String         @default("nil")
+  updatedBy String?
+  updatedAt DateTime?
 }


### PR DESCRIPTION
## Summary
- add confirmation dialog before deleting users in admin portal
- implement checklist items with first level activities and admin updates
- extend badge variants for checklist status indicators

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: Failed to fetch `Inter` and `Roboto` fonts)


------
https://chatgpt.com/codex/tasks/task_e_68c1cfa0803c83238826978d6b244899