### PR TITLE
fix: add checklistItems relation to User in Prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,8 +9,8 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
   directUrl = env("DIRECT_URL")
 }
 
@@ -28,26 +28,27 @@ enum ActivityStatus {
 }
 
 model User {
-  id            Int         @id @default(autoincrement())
-  name          String
-  email         String      @unique
-  password      String
-  passwordPlain String?
-  membership    Membership
-  startDate     DateTime
-  endDate       DateTime
-  phone         String?
-  imageUrl      String?
-  businessName  String?
-  companyAddress String?
-  annualRevenue Int?
-  employeeCount Int?
-  manufacturing Boolean?
-  businessChallenges String[] @default([])
-  status        String      @default("CREATED")
-  lastLogin     DateTime?
-  createdAt     DateTime    @default(now())
-  updatedAt     DateTime    @updatedAt
+  id                 Int             @id @default(autoincrement())
+  name               String
+  email              String          @unique
+  password           String
+  passwordPlain      String?
+  membership         Membership
+  startDate          DateTime
+  endDate            DateTime
+  phone              String?
+  imageUrl           String?
+  businessName       String?
+  companyAddress     String?
+  annualRevenue      Int?
+  employeeCount      Int?
+  manufacturing      Boolean?
+  businessChallenges String[]        @default([])
+  status             String          @default("CREATED")
+  lastLogin          DateTime?
+  createdAt          DateTime        @default(now())
+  updatedAt          DateTime        @updatedAt
+  checklistItems     ChecklistItem[]
 }
 
 model LearningModule {


### PR DESCRIPTION
## Summary
- add missing checklistItems relation to User model

## Testing
- `npx prisma validate` *(fails: Environment variable not found: DIRECT_URL)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c1d342a8008323bc4d3db6b01eb073