### PR TITLE
Add missing second and third level checklists

### DIFF
--- a/app/admin/users/[id]/page.js
+++ b/app/admin/users/[id]/page.js
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { prisma } from "@/lib/prisma";
-import { ensureFirstLevelChecklist, getChecklist } from "@/lib/checklists";
+import { ensureChecklists, getChecklist } from "@/lib/checklists";
 import UserProfile from "@/components/user-profile";
 
 export default async function AdminUserProfilePage({ params }) {
@@ -9,7 +9,7 @@ export default async function AdminUserProfilePage({ params }) {
   if (!user) {
     return <div className="p-4">User not found</div>;
   }
-  await ensureFirstLevelChecklist(user);
+  await ensureChecklists(user);
   const checklist = await getChecklist(id);
   const formattedUser = {
     ...user,

--- a/app/user/profile/page.js
+++ b/app/user/profile/page.js
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
-import { ensureFirstLevelChecklist, getChecklist } from "@/lib/checklists";
+import { ensureChecklists, getChecklist } from "@/lib/checklists";
 import UserProfile from "@/components/user-profile";
 
 export default async function UserProfilePage() {
@@ -11,7 +11,7 @@ export default async function UserProfilePage() {
   const id = Number(userIdCookie.value);
   const user = await prisma.user.findUnique({ where: { id } });
   if (!user) redirect("/");
-  await ensureFirstLevelChecklist(user);
+  await ensureChecklists(user);
   const checklist = await getChecklist(id);
   const formattedUser = {
     ...user,

--- a/lib/checklists.js
+++ b/lib/checklists.js
@@ -18,18 +18,62 @@ export const FIRST_LEVEL_ACTIVITIES = [
   "Process Flow Chart for each process under each Function",
 ];
 
-export async function ensureFirstLevelChecklist(user) {
-  const count = await prisma.checklistItem.count({
-    where: { userId: user.id, level: 1 },
-  });
-  if (count === 0) {
-    const data = FIRST_LEVEL_ACTIVITIES.map((activity) => ({
-      userId: user.id,
-      level: 1,
-      activity,
-      deadline: user.endDate,
-    }));
-    await prisma.checklistItem.createMany({ data });
+export const SECOND_LEVEL_ACTIVITIES = [
+  "Standard Operating Procedures (Functions)",
+  "Guidelines (applicable under each SOP)",
+  "Forms/Formats (applicable under each SOP)",
+  "KPIs for each function (Business Objectives)",
+  "Detailed Job Descriptions of all poistions",
+  "KRAs for each position (generic)",
+  "KRAs for each person working in the company/business eco-system (specific)",
+  "RACI Chart (Function Vs Positions)",
+  "Business Plan (1 Year)",
+  "Sample Learning & Development/ Training Plan covering Modules as per Skill Matrix",
+  "Data Sheets (in each function)- daily data feed",
+  "Data Analysis & MIS Graphs & Trend Charts",
+  "Management Information Systsem (MIS) for each process under each function",
+  "Business Management Manual (TOC) and draft manual",
+  "Busines Management Manual_Final Version 1.0",
+];
+
+export const THIRD_LEVEL_ACTIVITIES = [
+  "Quality Manual (ISO 9001:2015 Requirements)",
+  "Quality Assurance Plans for all processes and products",
+  "Finalise, approve and release Business Operations Manuual",
+  "Training on ISO 9001:2015 awareness across teams (4 levels)",
+  "Training on Internal Auditing Skills (CFT)",
+  "Internal Audit across departments and proceses and reports",
+  "Management Review and MOM",
+  "Filing Management / Online Google Sheets Update",
+  "Validate KPIs and KRAs performance for FY 2025-26 ( 9-12 months)",
+  "Market Research Report (TOM SOM SAM)",
+  "Financial Model (CMA) for 5 years",
+  "Sales Forecasting",
+  "Brand Manual (Logo and Positioning)",
+  "Factory Fitness Audit",
+  "ISO 9001:2015 Certification",
+];
+
+export async function ensureChecklists(user) {
+  const levels = [
+    { level: 1, activities: FIRST_LEVEL_ACTIVITIES },
+    { level: 2, activities: SECOND_LEVEL_ACTIVITIES },
+    { level: 3, activities: THIRD_LEVEL_ACTIVITIES },
+  ];
+
+  for (const { level, activities } of levels) {
+    const count = await prisma.checklistItem.count({
+      where: { userId: user.id, level },
+    });
+    if (count === 0) {
+      const data = activities.map((activity) => ({
+        userId: user.id,
+        level,
+        activity,
+        deadline: user.endDate,
+      }));
+      await prisma.checklistItem.createMany({ data });
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- include second and third level activity lists for onboarded users
- ensure all checklist levels are created for each user
- load complete checklist data on admin and user profile pages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c1d6bd6754832383f7c77f1a17ef8b