### PR TITLE
Fix onboarding form server action usage

### DIFF
--- a/app/user/onboarding/actions.js
+++ b/app/user/onboarding/actions.js
@@ -1,0 +1,13 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { completeOnboarding } from "@/lib/users";
+
+export async function submitOnboarding(formData) {
+  const userIdCookie = cookies().get("userId");
+  if (!userIdCookie) redirect("/");
+  const id = Number(userIdCookie.value);
+  await completeOnboarding(id, formData);
+  redirect("/user");
+}

--- a/app/user/onboarding/page.js
+++ b/app/user/onboarding/page.js
@@ -1,7 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
-import { completeOnboarding } from "@/lib/users";
 import OnboardingForm from "@/components/user/onboarding-form";
 
 export default async function OnboardingPage() {
@@ -21,12 +20,6 @@ export default async function OnboardingPage() {
     redirect("/user");
   }
 
-  async function handleSubmit(formData) {
-    "use server";
-    await completeOnboarding(id, formData);
-    redirect("/user");
-  }
-
   const formattedUser = {
     ...user,
     startDate: user.startDate.toISOString().split("T")[0],
@@ -35,7 +28,7 @@ export default async function OnboardingPage() {
   return (
     <div className="max-w-xl mx-auto p-4 space-y-4">
       <h1 className="text-2xl font-heading font-bold text-center">Onboarding</h1>
-      <OnboardingForm user={formattedUser} action={handleSubmit} />
+      <OnboardingForm user={formattedUser} />
     </div>
   );
 }

--- a/components/user/onboarding-form.js
+++ b/components/user/onboarding-form.js
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { submitOnboarding } from "@/app/user/onboarding/actions";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
@@ -14,7 +15,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-export default function OnboardingForm({ user, action }) {
+export default function OnboardingForm({ user }) {
   const [step, setStep] = useState(1);
   const [challenges, setChallenges] = useState([""]);
   const [imageError, setImageError] = useState("");
@@ -45,7 +46,7 @@ export default function OnboardingForm({ user, action }) {
   }
 
   return (
-    <form action={action} className="space-y-6" encType="multipart/form-data">
+    <form action={submitOnboarding} className="space-y-6" encType="multipart/form-data">
       <Card hidden={step !== 1}>
         <CardHeader>
           <CardTitle>Step 1</CardTitle>


### PR DESCRIPTION
## Summary
- avoid passing server actions to client components in user onboarding
- add server action submitOnboarding and wire form to it directly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1e06882a48323ac5c03e8c6e78c15