### PR TITLE
fix: expose checklist update as server action

### DIFF
--- a/lib/checklists.js
+++ b/lib/checklists.js
@@ -85,6 +85,7 @@ export async function getChecklist(userId) {
 }
 
 export async function updateChecklistItem(id, formData) {
+  "use server";
   const status = formData.get("status");
   const deadline = new Date(formData.get("deadline"));
   const remarks = formData.get("remarks");


### PR DESCRIPTION
## Summary
- mark `updateChecklistItem` with `"use server"` to enable server action in forms

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c25ed33d888323868b393e5ef35f14