### PR TITLE
fix: specify User table schema in assessment credits migration

### DIFF
--- a/prisma/migrations/20251105020000_assessment_credits/migration.sql
+++ b/prisma/migrations/20251105020000_assessment_credits/migration.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "User" ADD COLUMN "assessmentCredits" INTEGER NOT NULL DEFAULT 5;
+ALTER TABLE "public"."User" ADD COLUMN "assessmentCredits" INTEGER NOT NULL DEFAULT 5;


### PR DESCRIPTION
## Summary
- ensure assessment credits migration targets the `User` table in the `public` schema

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*
- `npx prisma validate` *(fails: Environment variable not found: DIRECT_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68c27671037c8323b72ea2e48116a2fe