### PR TITLE
Fix checklist status sync and assessment enhancements

### DIFF
--- a/app/api/assessment/route.js
+++ b/app/api/assessment/route.js
@@ -38,20 +38,24 @@ export async function POST(req) {
   let report = "";
   try {
     const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+      throw new Error("GEMINI_API_KEY not configured");
+    }
     const resp = await fetch(
       `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${apiKey}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          contents: [{ parts: [{ text: prompt }] }],
+          contents: [{ role: "user", parts: [{ text: prompt }] }],
         }),
       }
     );
     const data = await resp.json();
-    report =
-      data?.candidates?.[0]?.content?.parts?.[0]?.text ||
-      "Report generation failed.";
+    report = resp.ok
+      ? data?.candidates?.[0]?.content?.parts?.[0]?.text ||
+        "Report generation failed."
+      : data?.error?.message || "Report generation failed.";
   } catch (e) {
     report = "Report generation failed.";
   }

--- a/components/user-profile.js
+++ b/components/user-profile.js
@@ -156,6 +156,7 @@ export default function UserProfile({ user, checklist = [], isAdmin = false }) {
                                 name="deadline"
                                 defaultValue={formatDate(item.deadline)}
                                 className="border rounded px-2 py-1 text-xs"
+                                key={`deadline-${item.id}-${item.deadline}`}
                               />
                             </div>
                             <div className="flex flex-col">
@@ -166,6 +167,7 @@ export default function UserProfile({ user, checklist = [], isAdmin = false }) {
                                 name="status"
                                 defaultValue={item.status}
                                 className="border rounded px-2 py-1 text-xs"
+                                key={`status-${item.id}-${item.status}`}
                               >
                                 <option value="NOT_STARTED">Not started</option>
                                 <option value="IN_PROGRESS">In Progress</option>
@@ -180,6 +182,7 @@ export default function UserProfile({ user, checklist = [], isAdmin = false }) {
                                 name="remarks"
                                 defaultValue={item.remarks}
                                 className="h-8 text-xs"
+                                key={`remarks-${item.id}-${item.remarks}`}
                               />
                             </div>
                             <div className="flex justify-end">

--- a/components/user/assessment.js
+++ b/components/user/assessment.js
@@ -152,11 +152,13 @@ export default function Assessment({ user }) {
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">360 Business Maturity Assessment</h1>
       <p className="text-sm">{credits}/5 Report Credits remaining</p>
-      <h2 className="text-xl font-semibold">{current.title}</h2>
+      <h2 className="text-xl font-semibold">
+        {`Section ${step + 1} of ${sections.length}: ${current.title}`}
+      </h2>
       <div className="space-y-4">
-        {current.questions.map((q) => (
+        {current.questions.map((q, idx) => (
           <Card key={q} className="p-4 space-y-2">
-            <p>{q}</p>
+            <p>{`${idx + 1}. ${q}`}</p>
             <div className="flex flex-col gap-1">
               {options.map((o) => (
                 <label key={o} className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Ensure admin checklist status updates reflect correctly for users by forcing form inputs to re-render
- Improve assessment report generation with proper Gemini API request and error handling
- Number assessment sections and questions for clearer guidance

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c29aa4b5f08323a2f51e0528f766c3